### PR TITLE
Fix: Check if plugin file exists before loading

### DIFF
--- a/internal/core/services/plugin_manager.go
+++ b/internal/core/services/plugin_manager.go
@@ -120,6 +120,11 @@ func (pm *PluginManager) LoadGoPlugin(name string) (commons.DruidPluginInterface
 		path = "./druid_" + name
 	}
 
+	// Check if the plugin file exists before attempting to load it
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return nil, fmt.Errorf("plugin file not found: %s (looked in %s and ./druid_%s)", path, exPath+"/druid_"+name, name)
+	}
+
 	var cmd *exec.Cmd
 
 	if os.Getenv("DRUID_DEBUG_PATH") != "" {


### PR DESCRIPTION
## Problem

When druid-cli tries to load a plugin that doesn't exist (e.g., `druid_rcon`), it fails with a confusing error:

```
Error in Daemon Startup: unable to generate a checksum for the plugin ./druid_rcon: open ./druid_rcon: no such file or directory
```

This happens even when plugins are optional and the `--allow-plugin-errors` flag should handle it gracefully.

## Root Cause

The `LoadGoPlugin` function tries to generate a checksum for the plugin file without first verifying it exists. The checksum generation fails with an opaque error that doesn't clearly indicate the file is missing.

## Solution

- Add explicit file existence check before attempting to load the plugin
- Return a clearer error message that shows all searched paths
- This allows the `--allow-plugin-errors` flag to work properly
- Makes debugging easier by showing exactly where druid looked for the plugin

## Example Error (Before)
```
unable to generate a checksum for the plugin ./druid_rcon: open ./druid_rcon: no such file or directory
```

## Example Error (After)
```
plugin file not found: ./druid_rcon (looked in /usr/local/bin/druid_rcon and ./druid_rcon)
```

## Testing

Reproduced in CI environment where plugin files were missing. After this fix, the error message is clearer and the `--allow-plugin-errors` flag can properly handle the situation.

Related issue discovered in: https://github.com/highcard-dev/scrolls/pull/12