### PR TITLE
fix: allow credentialed public CORS

### DIFF
--- a/apps/druid/adapters/http/handlers/routes.go
+++ b/apps/druid/adapters/http/handlers/routes.go
@@ -52,10 +52,11 @@ func RegisterPublicRoutes(app *fiber.App, handlers RouteHandlers) {
 		authorizer = handlers.Server.ScrollHandler.authorizer
 	}
 	app.Use(cors.New(cors.Config{
-		AllowOrigins:  "*",
-		AllowMethods:  "GET,POST,PUT,DELETE,PATCH,OPTIONS,HEAD,PROPFIND,MOVE,MKCOL,COPY",
-		AllowHeaders:  "Origin,Content-Type,Accept,Authorization,X-Requested-With,Cache-Control,DNT,Keep-Alive,User-Agent,If-Modified-Since,Depth,Destination,Overwrite,If,Lock-Token,Timeout,Dav",
-		ExposeHeaders: "Druid-Version",
+		AllowOrigins:     "https://app.druid.gg,http://localhost:3000,http://127.0.0.1:3000",
+		AllowMethods:     "GET,POST,PUT,DELETE,PATCH,OPTIONS,HEAD,PROPFIND,MOVE,MKCOL,COPY",
+		AllowHeaders:     "Origin,Content-Type,Accept,Authorization,X-Requested-With,Cache-Control,DNT,Keep-Alive,User-Agent,If-Modified-Since,Depth,Destination,Overwrite,If,Lock-Token,Timeout,Dav",
+		AllowCredentials: true,
+		ExposeHeaders:    "Druid-Version",
 	}))
 	app.Get("/health", handlers.Server.GetHealthAuth)
 	app.Get("/.well-known/jwks.json", RuntimeJWKS(authorizer))

--- a/apps/druid/adapters/http/handlers/routes_test.go
+++ b/apps/druid/adapters/http/handlers/routes_test.go
@@ -50,8 +50,11 @@ func TestPublicRoutesAnswerCorsPreflight(t *testing.T) {
 	if resp.StatusCode != http.StatusNoContent {
 		t.Fatalf("preflight status = %d, want 204", resp.StatusCode)
 	}
-	if got := resp.Header.Get("Access-Control-Allow-Origin"); got != "*" {
-		t.Fatalf("allow origin = %q, want *", got)
+	if got := resp.Header.Get("Access-Control-Allow-Origin"); got != "http://127.0.0.1:3000" {
+		t.Fatalf("allow origin = %q, want request origin", got)
+	}
+	if got := resp.Header.Get("Access-Control-Allow-Credentials"); got != "true" {
+		t.Fatalf("allow credentials = %q, want true", got)
 	}
 }
 

--- a/config/helm-charts/druid-cli/chart_test.go
+++ b/config/helm-charts/druid-cli/chart_test.go
@@ -72,6 +72,8 @@ func TestChartRendersDefaultAndCustomValues(t *testing.T) {
 		"runtime.example.test",
 		"name: public",
 		"nginx.ingress.kubernetes.io/enable-cors",
+		"nginx.ingress.kubernetes.io/cors-allow-origin",
+		"nginx.ingress.kubernetes.io/cors-allow-credentials",
 		"storageClassName: \"local-path\"",
 	} {
 		if !strings.Contains(customManifest, want) {

--- a/config/helm-charts/druid-cli/values.yaml
+++ b/config/helm-charts/druid-cli/values.yaml
@@ -41,6 +41,8 @@ ingress:
   className: nginx
   annotations:
     nginx.ingress.kubernetes.io/enable-cors: "true"
+    nginx.ingress.kubernetes.io/cors-allow-origin: "https://app.druid.gg"
+    nginx.ingress.kubernetes.io/cors-allow-credentials: "true"
     nginx.ingress.kubernetes.io/cors-allow-methods: "GET, PUT, POST, DELETE, PATCH, OPTIONS, PROPFIND, MOVE, MKCOL, COPY"
     nginx.ingress.kubernetes.io/cors-allow-headers: "DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Authorization,depth,destination,overwrite,if,lock-token,timeout,dav"
     nginx.ingress.kubernetes.io/cors-expose-headers: "Druid-Version"


### PR DESCRIPTION
## Summary\n- allow credentialed CORS from app.druid.gg and local dev origins on public daemon routes\n- render matching druid-cli ingress CORS annotations\n- update route/chart tests so wildcard credentialed CORS cannot regress\n\n## Tests\n- go test ./apps/druid/adapters/http/handlers ./config/helm-charts/druid-cli\n- git diff --check