### PR TITLE
fix: add Steam runtime tools

### DIFF
--- a/Dockerfile.steamcmd
+++ b/Dockerfile.steamcmd
@@ -9,8 +9,10 @@ COPY --from=base /entrypoint.sh /entrypoint.sh
 
 RUN apt-get update && apt-get install -y \
     ca-certificates \
+    curl \
     jq \
     moreutils \
+    unzip \
     wget \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Summary\n- add curl to the Steam runtime image for LinuxGSM installers\n- add unzip for Rust Oxide prebuild/install flows\n\n## Validation\n- docker build --platform linux/amd64 --build-arg VERSION=v0.1.241 -f Dockerfile.steamcmd -t druid-steamcmd-tools-test .\n- docker run --rm --platform linux/amd64 --entrypoint sh druid-steamcmd-tools-test -lc 'command -v curl && command -v unzip && command -v steamcmd && command -v druid && druid version'\n- make build\n- make test