### PR TITLE
fix: add LGSM dependencies to SteamCMD image

### DIFF
--- a/Dockerfile.steamcmd
+++ b/Dockerfile.steamcmd
@@ -8,12 +8,27 @@ COPY --from=base /usr/bin/druid* /usr/bin/
 COPY --from=base /entrypoint.sh /entrypoint.sh
 
 RUN apt-get update && apt-get install -y \
+    bc \
+    binutils \
+    bsdmainutils \
+    bzip2 \
     ca-certificates \
+    cpio \
     curl \
+    distro-info \
+    file \
+    iproute2 \
     jq \
+    lib32stdc++6 \
     moreutils \
+    netcat-openbsd \
+    pigz \
+    python3 \
+    tmux \
     unzip \
+    uuid-runtime \
     wget \
+    xz-utils \
     && rm -rf /var/lib/apt/lists/*
 
 RUN ARCH=$(uname -m) && \


### PR DESCRIPTION
## Summary
- add the LGSM dependency baseline to the SteamCMD runtime image
- cover tools reported missing by LGSM clean installs: bc, binutils, bsdmainutils, bzip2, cpio, distro-info, file, iproute2, lib32stdc++6, netcat, pigz, python3, tmux, uuid-runtime, xz-utils

## Validation
- docker build --platform linux/amd64 --build-arg VERSION=v0.1.242 -f Dockerfile.steamcmd -t druid-steamcmd-lgsm-deps-test .
- docker run --rm --platform linux/amd64 --entrypoint sh druid-steamcmd-lgsm-deps-test -lc 'command -v curl && command -v unzip && command -v steamcmd && command -v druid && command -v bc && command -v tmux && command -v python3 && command -v ip && command -v ss && command -v file && command -v nc && command -v pigz && command -v xz && druid version'
- make build
- make test