### PR TITLE
fix: run hydrated queue after daemon restart

### DIFF
--- a/apps/druid/core/services/runtime_session_commands.go
+++ b/apps/druid/core/services/runtime_session_commands.go
@@ -84,7 +84,11 @@ func (s *RuntimeSession) Hydrate() error {
 	s.runtimeScroll.Status = deriveRuntimeScrollStatus(s.runtimeScroll.Procedures, s.scrollService.GetFile().Commands)
 	err := s.store.UpdateScroll(s.runtimeScroll)
 	s.mu.Unlock()
-	return err
+	if err != nil {
+		return err
+	}
+	s.triggerRunQueue()
+	return nil
 }
 
 func (s *RuntimeSession) AutoStartServe() error {

--- a/apps/druid/core/services/runtime_supervisor_test.go
+++ b/apps/druid/core/services/runtime_supervisor_test.go
@@ -402,6 +402,56 @@ func TestRuntimeSupervisorStartHydratesRunningScroll(t *testing.T) {
 	}
 }
 
+func TestRuntimeSupervisorStartRunsHydratedRestartCommand(t *testing.T) {
+	store := newTestStateStore(t)
+	scrollYAML := multiProcedureScrollYAML()
+	runtimeScroll := &domain.RuntimeScroll{
+		ID:         "running-restart-scroll",
+		Artifact:   "local",
+		Root:       "runtime://running-restart-scroll",
+		ScrollName: "cached",
+		ScrollYAML: scrollYAML,
+		Status:     domain.RuntimeScrollStatusRunning,
+		Procedures: domain.ProcedureStatusMap{
+			"start": {
+				"coldstart": {Status: domain.ScrollLockStatusRunning},
+				"start":     {Status: domain.ScrollLockStatusWaiting},
+			},
+		},
+	}
+	if err := store.CreateScroll(runtimeScroll); err != nil {
+		t.Fatal(err)
+	}
+	called := make(chan ports.RuntimeCommand, 1)
+	release := make(chan struct{})
+	supervisor := NewRuntimeSupervisor(store, coreservices.NewRuntimeScrollManager(store), &fakeWorkerBackend{
+		runCommand: func(command ports.RuntimeCommand) (*int, error) {
+			called <- command
+			<-release
+			return nil, nil
+		},
+	})
+
+	if err := supervisor.Start(); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		close(release)
+		if session := supervisor.sessions["running-restart-scroll"]; session != nil {
+			session.stopDeploymentQueue()
+		}
+	}()
+
+	select {
+	case command := <-called:
+		if command.Name != "start" {
+			t.Fatalf("hydrated command = %s, want start", command.Name)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for hydrated restart command to run")
+	}
+}
+
 func TestRuntimeSupervisorEnsureCanCreate(t *testing.T) {
 	artifact := t.TempDir()
 	if err := os.WriteFile(filepath.Join(artifact, "scroll.yaml"), []byte(cachedScrollYAML("start")), 0644); err != nil {


### PR DESCRIPTION
## Summary\n- trigger the runtime queue after hydration restores persisted procedure state\n- cover the production startup ordering where RuntimeSupervisor starts the session before Hydrate populates the queue\n\n## Why\nAfter daemon restart, a restart-mode command with a running Kubernetes job could remain in procedure state as running without reattaching the queue worker. If the rehydrated coldstarter job later completed, no waiter advanced the procedure to done or started the next procedure.\n\n## Tests\n- go test ./apps/druid/core/services -run 'TestRuntimeSupervisorStartRunsHydratedRestartCommand|TestRuntimeSupervisorStartHydratesRunningScroll|TestRuntimeSessionHydratePreservesProcedureStateWhenReattachingRunningRestart'\n- go test ./apps/druid/core/services ./internal/runtime/kubernetes ./internal/runtime/docker ./internal/core/services\n- go test ./...\n- git diff --check