### PR TITLE
fix: preserve steamcmd runtime files

### DIFF
--- a/Dockerfile.steamcmd
+++ b/Dockerfile.steamcmd
@@ -2,11 +2,11 @@ ARG VERSION=latest
 FROM artifacts.druid.gg/druid-team/druid:${VERSION} AS base
 FROM gameservermanagers/steamcmd:ubuntu-24.04
 
-RUN mkdir -p /tmp/steamcmd-seed/linux32 /tmp/steamcmd-seed/linux64 && \
-    cp /home/steam/.local/share/Steam/steamcmd/linux32/steamclient.so /tmp/steamcmd-seed/linux32/steamclient.so && \
-    cp /home/steam/.local/share/Steam/steamcmd/linux64/steamclient.so /tmp/steamcmd-seed/linux64/steamclient.so && \
-    test -s /tmp/steamcmd-seed/linux32/steamclient.so && \
-    test -s /tmp/steamcmd-seed/linux64/steamclient.so
+RUN mkdir -p /tmp/steamcmd-seed && \
+    cp -a /home/steam/.local/share/Steam/steamcmd /tmp/steamcmd-seed/steamcmd && \
+    test -s /tmp/steamcmd-seed/steamcmd/steamcmd.sh && \
+    test -s /tmp/steamcmd-seed/steamcmd/linux32/steamclient.so && \
+    test -s /tmp/steamcmd-seed/steamcmd/linux64/steamclient.so
 
 RUN if id -u steam >/dev/null 2>&1; then echo "Removing steam user from base image"; userdel -r steam || true; else echo "steam user not present"; fi
 
@@ -54,12 +54,10 @@ RUN groupadd -g $GID -o druid
 RUN useradd -m -u $UID -g $GID -o -s /bin/bash druid
 
 RUN mkdir -p \
-      /home/druid/.local/share/Steam/steamcmd/linux32 \
-      /home/druid/.local/share/Steam/steamcmd/linux64 \
+      /home/druid/.local/share/Steam \
       /home/druid/.steam/sdk32 \
       /home/druid/.steam/sdk64 && \
-    cp /tmp/steamcmd-seed/linux32/steamclient.so /home/druid/.local/share/Steam/steamcmd/linux32/steamclient.so && \
-    cp /tmp/steamcmd-seed/linux64/steamclient.so /home/druid/.local/share/Steam/steamcmd/linux64/steamclient.so && \
+    cp -a /tmp/steamcmd-seed/steamcmd /home/druid/.local/share/Steam/steamcmd && \
     ln -sfn /home/druid/.local/share/Steam /home/druid/.steam/root && \
     ln -sfn /home/druid/.local/share/Steam /home/druid/.steam/steam && \
     ln -sfn /home/druid/.local/share/Steam/steamcmd/linux32/steamclient.so /home/druid/.steam/sdk32/steamclient.so && \


### PR DESCRIPTION
## Summary\n- preserve the full upstream SteamCMD runtime directory before removing the steam user\n- seed /home/druid/.local/share/Steam/steamcmd so /usr/bin/steamcmd works as the druid user\n- keep sdk32/sdk64 steamclient symlinks for game server startup\n\n## Validation\n- docker build --platform linux/amd64 -f Dockerfile.steamcmd --build-arg VERSION=v0.1.247 -t druid-steamcmd-runtime-test .\n- docker run --rm --platform linux/amd64 --entrypoint sh druid-steamcmd-runtime-test -lc 'set -eu; id; pwd; test -x /home/druid/.local/share/Steam/steamcmd/steamcmd.sh; test -s /home/druid/.steam/sdk64/steamclient.so; test -s /home/druid/.steam/sdk32/steamclient.so; steamcmd +quit | sed -n "1,80p"'