### PR TITLE
fix: include lgsm steamcmd dependencies

### DIFF
--- a/Dockerfile.steamcmd
+++ b/Dockerfile.steamcmd
@@ -23,16 +23,19 @@ RUN mkdir -p /usr/share/man/man1 && \
     cpio \
     curl \
     distro-info \
+    expect \
     file \
     iproute2 \
     jq \
     lib32stdc++6 \
+    libxml2-utils \
     moreutils \
     netcat-openbsd \
     openjdk-21-jre-headless \
     pigz \
     python3 \
     rng-tools5 \
+    telnet \
     tmux \
     unzip \
     uuid-runtime \


### PR DESCRIPTION
## Summary
- install LGSM-reported missing dependencies in the steamcmd runtime image
- add expect, libxml2-utils/xmllint, and telnet so LGSM start/status helpers do not degrade at runtime

## Validation
- docker build -f Dockerfile.steamcmd --build-arg VERSION=v0.1.248 -t druid-steamcmd-deps-test:local .
- docker run --rm --entrypoint sh druid-steamcmd-deps-test:local -lc 'command -v expect && command -v xmllint && command -v telnet'
- git diff --check