### PR TITLE
Support plain HTTP registry login

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test build k3d-build-pull-image test-integration test-integration-docker test-integration-kubernetes kind-integration-up kind-integration-down
+.PHONY: test build k3d-build-pull-image watch test-integration test-integration-docker test-integration-kubernetes kind-integration-up kind-integration-down
 
 VERSION ?= "dev"
 DRUID_K8S_PULL_IMAGE ?= druid:local
@@ -7,6 +7,10 @@ INTEGRATION_TIMEOUT ?= 1200s
 KIND_CLUSTER ?= druid-cli-integration
 KIND_VERSION ?= v0.27.0
 GO_BIN ?= $(shell go env GOPATH)/bin
+DRUID_K8S_NAMESPACE ?= druid
+DRUID_WORKER_CALLBACK_LISTEN ?= 0.0.0.0:8083
+DRUID_WORKER_CALLBACK_URL ?= http://host.k3d.internal:8083
+DRUID_WATCH_ARGS ?= daemon --runtime kubernetes --listen 127.0.0.1:8081 --public-listen 127.0.0.1:8082 --worker-callback-listen $(DRUID_WORKER_CALLBACK_LISTEN) --worker-callback-url $(DRUID_WORKER_CALLBACK_URL) --unsafe-allow-unauthenticated-management --unsafe-allow-unauthenticated-public --k8s-namespace $(DRUID_K8S_NAMESPACE) --k8s-pull-image $(DRUID_K8S_PULL_IMAGE)
 
 generate-api: ## Generate API types from OpenAPI spec
 	@echo "Generating API types from OpenAPI spec..."
@@ -46,6 +50,10 @@ generate-md-docs:
 
 run: ## Run Daemon
 	go run ./apps/druid
+
+watch: ## Run Daemon with auto reload
+	@command -v air >/dev/null 2>&1 || go install github.com/air-verse/air@latest
+	air --build.cmd "CGO_ENABLED=0 go build -ldflags '-X github.com/highcard-dev/daemon/internal.Version=$(VERSION)' -o ./bin/druid ./apps/druid" --build.full_bin "DRUID_REGISTRY_PLAIN_HTTP=true ./bin/druid $(DRUID_WATCH_ARGS)"
 
 mock:
 	mockgen -source=internal/core/ports/services_ports.go -destination test/mock/services.go

--- a/internal/core/services/registry/oci.go
+++ b/internal/core/services/registry/oci.go
@@ -124,6 +124,7 @@ func ValidateCredentials(host, username, password string) error {
 		return fmt.Errorf("invalid registry host: %w", err)
 	}
 
+	reg.PlainHTTP = plainHTTPFromEnv()
 	reg.Client = &auth.Client{
 		Client: retry.DefaultClient,
 		Cache:  auth.DefaultCache,

--- a/internal/core/services/registry/oci_test.go
+++ b/internal/core/services/registry/oci_test.go
@@ -117,6 +117,17 @@ func fakeRegistry(t *testing.T) *httptest.Server {
 	return srv
 }
 
+func TestValidateCredentialsUsesPlainHTTPEnv(t *testing.T) {
+	t.Setenv("DRUID_REGISTRY_PLAIN_HTTP", "true")
+
+	srv := fakeRegistry(t)
+	registryHost := strings.TrimPrefix(srv.URL, "http://")
+
+	if err := ValidateCredentials(registryHost, "admin", "admin"); err != nil {
+		t.Fatalf("ValidateCredentials failed: %v", err)
+	}
+}
+
 // TestPushDataChunkPathNotDoubled calls OciClient.Push directly with a
 // relative scroll folder containing a data directory, pushing to a fake
 // in-process OCI registry. This verifies the data-chunk file paths are


### PR DESCRIPTION
## Summary
- make ValidateCredentials honor DRUID_REGISTRY_PLAIN_HTTP
- add a regression test against a plain HTTP httptest registry

## Tests
- GOCACHE=/tmp/druid-local-go-cache go test ./internal/core/services/registry