### PR TITLE
Fix WSL worker callback routing

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -53,6 +53,7 @@ jobs:
             .docker/druid-install-command.sh
 
   prerelease:
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     needs: [unit-tests, integration-tests, validate-api, build]
     outputs:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,28 @@
+# Druid CLI Agent Guide
+
+## Local daemon command selection
+
+Keep the normal Linux and macOS development path on the existing command:
+
+```bash
+make watch
+```
+
+That command uses `http://host.k3d.internal:8083` for Kubernetes worker
+callbacks and must remain free of Windows or WSL auto-detection.
+
+When Docker Desktop runs on Windows and the repository is executed inside
+WSL2, use the explicit Windows command instead:
+
+```bash
+make watch-windows
+```
+
+The Windows command derives the current WSL source address and passes its
+callback URL to the unchanged `make watch` implementation. Set
+`DRUID_HOST_SERVICES_IP` to override address discovery, or set
+`DRUID_WORKER_CALLBACK_URL` to override the complete callback URL.
+
+Do not use `make watch-windows` on native Linux or macOS. Keep future
+platform-specific setup additive instead of adding OS detection to `make
+watch`.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test build k3d-build-pull-image watch test-integration test-integration-docker test-integration-kubernetes kind-integration-up kind-integration-down
+.PHONY: test build k3d-build-pull-image watch watch-windows test-integration test-integration-docker test-integration-kubernetes kind-integration-up kind-integration-down
 
 VERSION ?= "dev"
 DRUID_K8S_PULL_IMAGE ?= druid:local
@@ -9,9 +9,7 @@ KIND_VERSION ?= v0.27.0
 GO_BIN ?= $(shell go env GOPATH)/bin
 DRUID_K8S_NAMESPACE ?= druid
 DRUID_WORKER_CALLBACK_LISTEN ?= 0.0.0.0:8083
-DRUID_IS_WSL ?= $(shell if grep -qi microsoft /proc/sys/kernel/osrelease 2>/dev/null; then printf 1; fi)
-DRUID_HOST_SERVICES_IP ?= $(if $(DRUID_IS_WSL),$(shell ip -4 route get 1.1.1.1 2>/dev/null | sed -n 's/.* src \([^ ]*\).*/\1/p' | head -n 1),)
-DRUID_WORKER_CALLBACK_URL ?= $(if $(DRUID_IS_WSL),$(if $(strip $(DRUID_HOST_SERVICES_IP)),http://$(strip $(DRUID_HOST_SERVICES_IP)):8083,$(error Unable to determine the WSL callback address; set DRUID_WORKER_CALLBACK_URL explicitly)),http://host.k3d.internal:8083)
+DRUID_WORKER_CALLBACK_URL ?= http://host.k3d.internal:8083
 DRUID_WATCH_ARGS ?= daemon --runtime kubernetes --listen 127.0.0.1:8081 --public-listen 127.0.0.1:8082 --worker-callback-listen $(DRUID_WORKER_CALLBACK_LISTEN) --worker-callback-url $(DRUID_WORKER_CALLBACK_URL) --unsafe-allow-unauthenticated-management --unsafe-allow-unauthenticated-public --k8s-namespace $(DRUID_K8S_NAMESPACE) --k8s-pull-image $(DRUID_K8S_PULL_IMAGE)
 
 generate-api: ## Generate API types from OpenAPI spec
@@ -56,6 +54,9 @@ run: ## Run Daemon
 watch: ## Run Daemon with auto reload
 	@command -v air >/dev/null 2>&1 || go install github.com/air-verse/air@latest
 	air --build.cmd "CGO_ENABLED=0 go build -ldflags '-X github.com/highcard-dev/daemon/internal.Version=$(VERSION)' -o ./bin/druid ./apps/druid" --build.full_bin "DRUID_REGISTRY_PLAIN_HTTP=true ./bin/druid $(DRUID_WATCH_ARGS)"
+
+watch-windows: ## Run Daemon with auto reload on Windows through WSL
+	./scripts/watch-windows.sh
 
 mock:
 	mockgen -source=internal/core/ports/services_ports.go -destination test/mock/services.go

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,9 @@ KIND_VERSION ?= v0.27.0
 GO_BIN ?= $(shell go env GOPATH)/bin
 DRUID_K8S_NAMESPACE ?= druid
 DRUID_WORKER_CALLBACK_LISTEN ?= 0.0.0.0:8083
-DRUID_WORKER_CALLBACK_URL ?= http://host.k3d.internal:8083
+DRUID_IS_WSL ?= $(shell if grep -qi microsoft /proc/sys/kernel/osrelease 2>/dev/null; then printf 1; fi)
+DRUID_HOST_SERVICES_IP ?= $(if $(DRUID_IS_WSL),$(shell ip -4 route get 1.1.1.1 2>/dev/null | sed -n 's/.* src \([^ ]*\).*/\1/p' | head -n 1),)
+DRUID_WORKER_CALLBACK_URL ?= $(if $(DRUID_IS_WSL),$(if $(strip $(DRUID_HOST_SERVICES_IP)),http://$(strip $(DRUID_HOST_SERVICES_IP)):8083,$(error Unable to determine the WSL callback address; set DRUID_WORKER_CALLBACK_URL explicitly)),http://host.k3d.internal:8083)
 DRUID_WATCH_ARGS ?= daemon --runtime kubernetes --listen 127.0.0.1:8081 --public-listen 127.0.0.1:8082 --worker-callback-listen $(DRUID_WORKER_CALLBACK_LISTEN) --worker-callback-url $(DRUID_WORKER_CALLBACK_URL) --unsafe-allow-unauthenticated-management --unsafe-allow-unauthenticated-public --k8s-namespace $(DRUID_K8S_NAMESPACE) --k8s-pull-image $(DRUID_K8S_PULL_IMAGE)
 
 generate-api: ## Generate API types from OpenAPI spec

--- a/scripts/watch-windows.sh
+++ b/scripts/watch-windows.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+callback_url="${DRUID_WORKER_CALLBACK_URL:-}"
+
+if [[ -z "$callback_url" ]]; then
+    host_services_ip="${DRUID_HOST_SERVICES_IP:-}"
+    if [[ -z "$host_services_ip" ]]; then
+        host_services_ip="$({
+            ip -4 route get 1.1.1.1 2>/dev/null \
+                | sed -n 's/.* src \([^ ]*\).*/\1/p' \
+                | head -n 1
+        } || true)"
+    fi
+
+    if [[ -z "$host_services_ip" ]]; then
+        echo "Unable to determine the WSL callback address; set DRUID_WORKER_CALLBACK_URL explicitly." >&2
+        exit 1
+    fi
+
+    callback_url="http://${host_services_ip}:8083"
+fi
+
+exec make -C "$ROOT" watch DRUID_WORKER_CALLBACK_URL="$callback_url"


### PR DESCRIPTION
## Summary

- add an explicit `make watch-windows` entrypoint for Docker Desktop development through WSL2
- derive the current WSL source address for Kubernetes worker callbacks while preserving explicit URL/IP overrides
- keep the existing `make watch` behavior unchanged for native Linux and macOS
- skip the secret-dependent prerelease job for pull requests originating from forks

## Root cause

Under Docker Desktop with the daemon running inside WSL2, `host.k3d.internal` resolves to the Windows-side Docker gateway rather than the daemon's current WSL address. Kubernetes materialization workers could pull artifacts but could not deliver completion callbacks, so deployments remained locked and the unlock request eventually timed out.

## Review feedback addressed

Platform-specific behavior is now explicit and additive: Windows users select `make watch-windows`; the normal `make watch` path contains no Windows/WSL auto-detection. Fork pull requests also no longer enter the prerelease job that depends on repository credentials.

## Validation

- `bash -n scripts/watch-windows.sh`
- `go test ./...`
- full local Windows/WSL stack test: the Kubernetes worker callback completed successfully and the test `ScrollDeployment` reached `Active`

## Deliberately separate work

The Docker build-cache optimization is not part of this feedback PR. It is isolated in #93 so routing fixes and performance work can be reviewed independently.
