### PR TITLE
fix: provision runtime ServiceAccounts at startup

### DIFF
--- a/internal/runtime/kubernetes/dev.go
+++ b/internal/runtime/kubernetes/dev.go
@@ -49,7 +49,9 @@ func (b *Backend) StartDev(ctx context.Context, action ports.RuntimeDevAction) e
 		zap.Strings("commands", action.HotReloadCommands),
 		zap.String("image", b.config.PullImage),
 	)
-	if err := b.ensureRuntimeServiceAccount(ctx, namespace, runtimeDevServiceAccount); err != nil {
+	// Keep this idempotent bootstrap for deployments created before the first
+	// materialization completed.
+	if err := b.ensureRuntimeServiceAccounts(ctx, namespace); err != nil {
 		return err
 	}
 	sts := devStatefulSetSpec(namespace, action.RootRef, pvc, b.config.PullImage, action, b.config.RegistrySecret, b.config.ServiceAccountAudience)

--- a/internal/runtime/kubernetes/resources_test.go
+++ b/internal/runtime/kubernetes/resources_test.go
@@ -318,6 +318,13 @@ func TestSpawnPullWorkerCreateUsesFinalPVCAndWorkerJob(t *testing.T) {
 	if got := pvcs.Items[0].Spec.Resources.Requests.Storage().String(); got != "25Gi" {
 		t.Fatalf("pvc storage = %s, want 25Gi", got)
 	}
+	accounts, err := client.CoreV1().ServiceAccounts("games").List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(accounts.Items) != 2 {
+		t.Fatalf("service accounts = %#v, want both runtime identities", accounts.Items)
+	}
 	if len(jobs) != 1 {
 		t.Fatalf("jobs = %d, want 1", len(jobs))
 	}

--- a/internal/runtime/kubernetes/workers.go
+++ b/internal/runtime/kubernetes/workers.go
@@ -53,14 +53,16 @@ func (b *Backend) SpawnPullWorker(ctx context.Context, action ports.RuntimeWorke
 		zap.Bool("registry_plain_http", b.config.RegistryPlainHTTP),
 		zap.Bool("has_registry_credentials", len(action.RegistryCredentials) > 0),
 	)
+	// A deployment obtains both workload identities as part of its first
+	// materialization, before creating any runtime resources.
+	if err := b.ensureRuntimeServiceAccounts(ctx, namespace); err != nil {
+		return err
+	}
 	if action.Mode == ports.RuntimeWorkerModeCreate {
 		if err := b.ensurePVC(ctx, namespace, pvc, action.Storage); err != nil {
 			logger.Log().Error("Failed to ensure runtime PVC for pull worker", zap.String("runtime_id", action.RuntimeID), zap.String("namespace", namespace), zap.String("pvc", pvc), zap.Error(err))
 			return err
 		}
-	}
-	if err := b.ensureRuntimeServiceAccount(ctx, namespace, runtimeWorkerServiceAccount); err != nil {
-		return err
 	}
 	registryConfigSecret, cleanupRegistryConfig, err := b.createRegistryConfigSecret(ctx, namespace, action.Artifact+action.RuntimeID, action.RegistryCredentials)
 	if err != nil {

--- a/internal/runtime/kubernetes/workload_identity.go
+++ b/internal/runtime/kubernetes/workload_identity.go
@@ -92,6 +92,18 @@ func (b *Backend) ensureRuntimeServiceAccount(ctx context.Context, namespace str
 	return err
 }
 
+// ensureRuntimeServiceAccounts provisions the fixed identities used by Druid
+// runtime workloads. Create plus AlreadyExists is an atomic existence check,
+// so concurrent deployment startup cannot race between a separate get/create.
+func (b *Backend) ensureRuntimeServiceAccounts(ctx context.Context, namespace string) error {
+	for _, name := range []string{runtimeDevServiceAccount, runtimeWorkerServiceAccount} {
+		if err := b.ensureRuntimeServiceAccount(ctx, namespace, name); err != nil {
+			return fmt.Errorf("ensure runtime service account %q: %w", name, err)
+		}
+	}
+	return nil
+}
+
 func (b *Backend) isOperatorServiceAccount(namespace string, serviceAccount string) bool {
 	expected := strings.TrimSpace(b.config.OperatorServiceAccount)
 	if expected == "" {

--- a/internal/runtime/kubernetes/workload_identity_test.go
+++ b/internal/runtime/kubernetes/workload_identity_test.go
@@ -60,6 +60,33 @@ func TestAuthenticateWorkloadRejectsCrossRuntimeLabel(t *testing.T) {
 	}
 }
 
+func TestEnsureRuntimeServiceAccountsCreatesBothAndIsIdempotent(t *testing.T) {
+	client := k8sfake.NewSimpleClientset()
+	backend := NewWithClient(Config{Namespace: "games"}, nil, client)
+
+	if err := backend.ensureRuntimeServiceAccounts(context.Background(), "games"); err != nil {
+		t.Fatal(err)
+	}
+	if err := backend.ensureRuntimeServiceAccounts(context.Background(), "games"); err != nil {
+		t.Fatal(err)
+	}
+	accounts, err := client.CoreV1().ServiceAccounts("games").List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(accounts.Items) != 2 {
+		t.Fatalf("service accounts = %#v, want two", accounts.Items)
+	}
+	for _, account := range accounts.Items {
+		if account.Labels[labelManagedBy] != "druid" || account.Labels[labelComponent] != "workload-identity" {
+			t.Fatalf("service account labels = %#v", account.Labels)
+		}
+		if account.AutomountServiceAccountToken == nil || *account.AutomountServiceAccountToken {
+			t.Fatalf("service account automount = %#v, want false", account.AutomountServiceAccountToken)
+		}
+	}
+}
+
 func tokenReviewReactor(serviceAccount, namespace, podName, podUID string, authenticated bool) k8stesting.ReactionFunc {
 	return func(k8stesting.Action) (bool, runtime.Object, error) {
 		return true, &authv1.TokenReview{Status: authv1.TokenReviewStatus{


### PR DESCRIPTION
## Summary
- provision the fixed dev and worker ServiceAccounts before a deployment first materializes
- retain the idempotent Developer Mode bootstrap for existing deployments
- cover creation, idempotency, labels, and disabled default token mounting

## Validation
- go test ./internal/runtime/kubernetes
- go test ./...
