### PR TITLE
fix(kubernetes): co-locate RWO runtime workloads

### DIFF
--- a/internal/runtime/kubernetes/dev.go
+++ b/internal/runtime/kubernetes/dev.go
@@ -55,6 +55,9 @@ func (b *Backend) StartDev(ctx context.Context, action ports.RuntimeDevAction) e
 		return err
 	}
 	sts := devStatefulSetSpec(namespace, action.RootRef, pvc, b.config.PullImage, action, b.config.RegistrySecret, b.config.ServiceAccountAudience)
+	if err := b.pinPodToRuntimeNode(ctx, namespace, pvc, &sts.Spec.Template.Spec); err != nil {
+		return err
+	}
 	existing, err := b.client.AppsV1().StatefulSets(namespace).Get(ctx, sts.Name, metav1.GetOptions{})
 	switch {
 	case apierrors.IsNotFound(err):

--- a/internal/runtime/kubernetes/procedure_attempts.go
+++ b/internal/runtime/kubernetes/procedure_attempts.go
@@ -138,6 +138,9 @@ func (b *Backend) createOrReuseProcedureJob(ctx context.Context, namespace strin
 	if err != nil {
 		return nil, err
 	}
+	if err := b.pinPodToRuntimeNode(ctx, namespace, pvc, &job.Spec.Template.Spec); err != nil {
+		return nil, err
+	}
 	created, err := b.client.BatchV1().Jobs(namespace).Create(ctx, job, metav1.CreateOptions{})
 	if err != nil {
 		return nil, err

--- a/internal/runtime/kubernetes/procedures.go
+++ b/internal/runtime/kubernetes/procedures.go
@@ -232,7 +232,7 @@ func (b *Backend) ensurePersistentProcedure(ctx context.Context, scrollID string
 		logger.Log().Error("Failed to reconcile Kubernetes persistent procedure Services", zap.String("scroll_id", scrollID), zap.String("command", commandName), zap.String("procedure", procedureName), zap.Error(err))
 		return err
 	}
-	namespace, _, err := parseRef(root)
+	namespace, pvc, err := parseRef(root)
 	if err != nil {
 		logger.Log().Error("Kubernetes persistent procedure root ref invalid", zap.String("scroll_id", scrollID), zap.String("command", commandName), zap.String("procedure", procedureName), zap.String("root", root), zap.Error(err))
 		return err
@@ -240,6 +240,9 @@ func (b *Backend) ensurePersistentProcedure(ctx context.Context, scrollID string
 	statefulSet, err := procedureStatefulSetSpec(namespace, root, commandName, procedureName, resourceName, procedure, env, b.config.RegistrySecret)
 	if err != nil {
 		logger.Log().Error("Failed to build Kubernetes persistent procedure StatefulSet", zap.String("scroll_id", scrollID), zap.String("command", commandName), zap.String("procedure", procedureName), zap.String("namespace", namespace), zap.Error(err))
+		return err
+	}
+	if err := b.pinPodToRuntimeNode(ctx, namespace, pvc, &statefulSet.Spec.Template.Spec); err != nil {
 		return err
 	}
 	logger.Log().Info("Reconciling Kubernetes persistent procedure",

--- a/internal/runtime/kubernetes/resources_test.go
+++ b/internal/runtime/kubernetes/resources_test.go
@@ -122,6 +122,59 @@ func TestProcedureJobSpecBuildsDeterministicMountsAndLabels(t *testing.T) {
 	}
 }
 
+func TestPinPodToRuntimeNodeUsesRunningPVCConsumer(t *testing.T) {
+	root := ref("druid", "druid-static-web-data")
+	runtimePod := runningProcedurePod("druid", root, "start", "start", 1, "runtime-pod", "start-job")
+	runtimePod.Spec.Volumes = []corev1.Volume{pvcVolume("data", "druid-static-web-data")}
+	client := fake.NewSimpleClientset(runtimePod)
+	backend := NewWithClient(Config{Namespace: "druid"}, coreservices.NewConsoleManager(coreservices.NewLogManager()), client)
+
+	podSpec := corev1.PodSpec{}
+	if err := backend.pinPodToRuntimeNode(context.Background(), "druid", "druid-static-web-data", &podSpec); err != nil {
+		t.Fatal(err)
+	}
+	if got := podSpec.NodeSelector[corev1.LabelHostname]; got != "node-a" {
+		t.Fatalf("node selector = %q, want node-a", got)
+	}
+}
+
+func TestPinPodToRuntimeNodeIgnoresInactiveOrUnrelatedPods(t *testing.T) {
+	root := ref("druid", "druid-static-web-data")
+	inactive := runningProcedurePod("druid", root, "start", "start", 1, "inactive", "start-job")
+	inactive.Status.Phase = corev1.PodSucceeded
+	inactive.Spec.Volumes = []corev1.Volume{pvcVolume("data", "druid-static-web-data")}
+	unrelated := runningProcedurePod("druid", root, "start", "start", 2, "unrelated", "other-job")
+	unrelated.Name = "unrelated-pod"
+	unrelated.Spec.Volumes = []corev1.Volume{pvcVolume("data", "another-pvc")}
+	client := fake.NewSimpleClientset(inactive, unrelated)
+	backend := NewWithClient(Config{Namespace: "druid"}, coreservices.NewConsoleManager(coreservices.NewLogManager()), client)
+
+	podSpec := corev1.PodSpec{}
+	if err := backend.pinPodToRuntimeNode(context.Background(), "druid", "druid-static-web-data", &podSpec); err != nil {
+		t.Fatal(err)
+	}
+	if len(podSpec.NodeSelector) != 0 {
+		t.Fatalf("node selector = %#v, want no selector", podSpec.NodeSelector)
+	}
+}
+
+func TestCreateOrReuseProcedureJobPinsToRuntimePVCNode(t *testing.T) {
+	root := ref("druid", "druid-static-web-data")
+	runtimePod := runningProcedurePod("druid", root, "start", "start", 1, "runtime-pod", "start-job")
+	runtimePod.Spec.Volumes = []corev1.Volume{pvcVolume("data", "druid-static-web-data")}
+	client := fake.NewSimpleClientset(runtimePod)
+	backend := NewWithClient(Config{Namespace: "druid"}, coreservices.NewConsoleManager(coreservices.NewLogManager()), client)
+	procedure := &domain.Procedure{Image: "alpine:3.20", Command: []string{"true"}}
+
+	job, err := backend.createOrReuseProcedureJob(context.Background(), "druid", root, "build", "build", "build-job", procedure, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := job.Spec.Template.Spec.NodeSelector[corev1.LabelHostname]; got != "node-a" {
+		t.Fatalf("node selector = %q, want node-a", got)
+	}
+}
+
 func TestDevStatefulSetMountsRuntimeRootAsScrollRoot(t *testing.T) {
 	root := ref("druid", "druid-ui-data")
 	statefulSet := devStatefulSetSpec("druid", root, "druid-ui-data", "druid:local", ports.RuntimeDevAction{

--- a/internal/runtime/kubernetes/scheduling.go
+++ b/internal/runtime/kubernetes/scheduling.go
@@ -1,0 +1,51 @@
+package kubernetes
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+// pinPodToRuntimeNode keeps concurrent users of an RWO runtime PVC on the
+// node where its active runtime pod is already attached. Kubernetes permits
+// multiple read-write mounts of an RWO volume on one node, but not across
+// nodes.
+func (b *Backend) pinPodToRuntimeNode(ctx context.Context, namespace string, pvc string, podSpec *corev1.PodSpec) error {
+	nodeName, err := b.runtimePVCNode(ctx, namespace, pvc)
+	if err != nil || nodeName == "" {
+		return err
+	}
+	if podSpec.NodeSelector == nil {
+		podSpec.NodeSelector = map[string]string{}
+	}
+	podSpec.NodeSelector[corev1.LabelHostname] = nodeName
+	return nil
+}
+
+func (b *Backend) runtimePVCNode(ctx context.Context, namespace string, pvc string) (string, error) {
+	pods, err := b.client.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: labels.SelectorFromSet(labels.Set{labelScrollID: dnsLabel(pvc)}).String(),
+	})
+	if err != nil {
+		return "", err
+	}
+	for idx := range pods.Items {
+		pod := &pods.Items[idx]
+		if pod.Status.Phase != corev1.PodRunning || pod.Spec.NodeName == "" || !podUsesPVC(pod, pvc) {
+			continue
+		}
+		return pod.Spec.NodeName, nil
+	}
+	return "", nil
+}
+
+func podUsesPVC(pod *corev1.Pod, pvc string) bool {
+	for _, volume := range pod.Spec.Volumes {
+		if volume.PersistentVolumeClaim != nil && volume.PersistentVolumeClaim.ClaimName == pvc {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/runtime/kubernetes/workers.go
+++ b/internal/runtime/kubernetes/workers.go
@@ -71,6 +71,9 @@ func (b *Backend) SpawnPullWorker(ctx context.Context, action ports.RuntimeWorke
 	}
 	defer cleanupRegistryConfig()
 	job := workerPullJobSpec(namespace, jobName("worker-pull", action.RootRef, shortHash(string(action.Mode)+action.Artifact)), pvc, b.config.PullImage, action, b.config.RegistrySecret, registryConfigSecret, b.config.RegistryPlainHTTP, b.config.ServiceAccountAudience)
+	if err := b.pinPodToRuntimeNode(ctx, namespace, pvc, &job.Spec.Template.Spec); err != nil {
+		return err
+	}
 	setJobDeadlineFromContext(ctx, job)
 	logger.Log().Debug("Kubernetes pull worker job built", zap.String("runtime_id", action.RuntimeID), zap.String("namespace", namespace), zap.String("job", job.Name))
 	if err := b.runHelperJob(ctx, job); err != nil {
@@ -101,6 +104,9 @@ func (b *Backend) BackupRuntime(ctx context.Context, root string, artifact strin
 	}
 	defer cleanupRegistryConfig()
 	job := backupJobSpec(namespace, jobName("backup", root, shortHash(artifact)), pvc, b.config.PullImage, artifact, b.config.RegistrySecret, registryConfigSecret, b.config.RegistryPlainHTTP)
+	if err := b.pinPodToRuntimeNode(ctx, namespace, pvc, &job.Spec.Template.Spec); err != nil {
+		return err
+	}
 	setJobDeadlineFromContext(ctx, job)
 	if err := b.runHelperJob(ctx, job); err != nil {
 		logger.Log().Error("Kubernetes runtime backup failed", zap.String("namespace", namespace), zap.String("pvc", pvc), zap.String("artifact", artifact), zap.String("job", job.Name), zap.Error(err))


### PR DESCRIPTION
## Problem
One-shot runtime Jobs and the Developer Mode StatefulSet mount the same RWO PVC as the active deployment but had no node constraint. Kubernetes could schedule them on another node, producing a Multi-Attach error and permanently blocking the command queue.

## Change
- discover the node of the running pod that mounts the runtime PVC
- pin procedure Jobs, helper Jobs, persistent procedures, and the Developer Mode workload to that node
- leave workloads unconstrained when there is no active PVC consumer

## Validation
- `go test ./internal/runtime/kubernetes`
- `go test ./...`
- `go test -race ./internal/runtime/kubernetes`
- production reproduction: Developer Mode init Job was scheduled away from an active RWO PVC and hit `FailedAttachVolume`