### PR TITLE
fix(dev): deliver watcher build events

### DIFF
--- a/apps/druid/adapters/cli/client/dev.go
+++ b/apps/druid/adapters/cli/client/dev.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"mime"
 	"net/http"
@@ -140,9 +139,7 @@ func runDevServer() error {
 			return err
 		}
 	}
-	broadcast := domain.NewHub()
-	go broadcast.Run()
-	queue := &devTriggerQueue{broadcast: broadcast, commands: append([]string(nil), devCommands...)}
+	queue := &devTriggerQueue{}
 	watch := coreservices.NewDevService(queue, devScrollService{commands: devCommands})
 	if len(devCommands) > 0 {
 		if err := watch.SetHotReloadCommands(devCommands); err != nil {
@@ -152,7 +149,7 @@ func runDevServer() error {
 	if err := watch.StartWatching(root, devWatchPaths...); err != nil {
 		return err
 	}
-	app := newDevApp(root, broadcast, queue, auth)
+	app := newDevApp(root, watch, auth)
 	return app.Listen(devListen)
 }
 
@@ -163,7 +160,7 @@ type devAuth struct {
 	ownerID   string
 }
 
-func newDevApp(root string, broadcast *domain.BroadcastChannel, queue *devTriggerQueue, authOpt ...devAuth) *fiber.App {
+func newDevApp(root string, watch ports.WatchServiceInterface, authOpt ...devAuth) *fiber.App {
 	auth := devAuth{}
 	if len(authOpt) > 0 {
 		auth = authOpt[0]
@@ -174,7 +171,7 @@ func newDevApp(root string, broadcast *domain.BroadcastChannel, queue *devTrigge
 		ErrorHandler:          runtimehandlers.ErrorHandler,
 	})
 	app.Use(runtimehandlers.RequestLogger)
-	server := devServer{root: root, broadcast: broadcast, queue: queue, auth: auth}
+	server := devServer{root: root, watch: watch, auth: auth}
 	app.Use(func(c *fiber.Ctx) error {
 		c.Set("Access-Control-Allow-Origin", "*")
 		c.Set("Access-Control-Allow-Methods", "GET,HEAD,PUT,OPTIONS,PROPFIND,MKCOL,MOVE,COPY,DELETE")
@@ -192,25 +189,15 @@ func newDevApp(root string, broadcast *domain.BroadcastChannel, queue *devTrigge
 		LockSystem: webdav.NewMemLS(),
 	})
 	app.All("/webdav/*", func(c *fiber.Ctx) error {
-		if err := webdavHandler(c); err != nil {
-			return err
-		}
-		switch c.Method() {
-		case fiber.MethodPut, "DELETE", "MKCOL", "MOVE", "COPY":
-			if c.Response().StatusCode() < fiber.StatusBadRequest {
-				server.queue.Trigger()
-			}
-		}
-		return nil
+		return webdavHandler(c)
 	})
 	return app
 }
 
 type devServer struct {
-	root      string
-	broadcast *domain.BroadcastChannel
-	queue     *devTriggerQueue
-	auth      devAuth
+	root  string
+	watch ports.WatchServiceInterface
+	auth  devAuth
 }
 
 func (s devServer) GetHealth(c *fiber.Ctx) error { return c.SendString("ok") }
@@ -269,11 +256,11 @@ func (s devServer) PutFile(c *fiber.Ctx, params devapi.PutFileParams) error {
 func (s devServer) WatchNotifications(c *fiber.Ctx) error {
 	return websocket.New(func(conn *websocket.Conn) {
 		defer conn.Close()
-		sub := s.broadcast.Subscribe()
+		sub := s.watch.Subscribe()
 		if sub == nil {
 			return
 		}
-		defer s.broadcast.Unsubscribe(sub)
+		defer s.watch.Unsubscribe(sub)
 		ping := time.NewTicker(30 * time.Second)
 		defer ping.Stop()
 		for {
@@ -327,7 +314,6 @@ func (s devServer) writeFile(c *fiber.Ctx, raw string) error {
 	if err := os.WriteFile(fullPath, c.Body(), 0644); err != nil {
 		return err
 	}
-	s.queue.Trigger()
 	return c.SendStatus(fiber.StatusNoContent)
 }
 
@@ -344,35 +330,14 @@ func devFilePath(root string, raw string) (string, error) {
 	return full, nil
 }
 
-type devTriggerQueue struct {
-	broadcast *domain.BroadcastChannel
-	commands  []string
-}
+type devTriggerQueue struct{}
 
-func (q *devTriggerQueue) AddTempItem(string) error { return q.Trigger() }
+func (q *devTriggerQueue) AddTempItem(string) error { return nil }
 func (q *devTriggerQueue) AddTempItemWithWait(command string) error {
 	return q.runCommand(command)
 }
 func (q *devTriggerQueue) GetQueue() map[string]domain.ScrollLockStatus {
 	return nil
-}
-
-func (q *devTriggerQueue) Trigger() error {
-	for _, command := range q.commands {
-		q.broadcastEvent("build-started")
-		err := q.runCommand(command)
-		if err != nil {
-			q.broadcastEvent("build-failed")
-			return err
-		}
-		q.broadcastEvent("build-ended")
-	}
-	return nil
-}
-
-func (q *devTriggerQueue) broadcastEvent(name string) {
-	data, _ := json.Marshal(map[string]any{"command_key": name, "timestamp": time.Now()})
-	q.broadcast.Broadcast(data)
 }
 
 func (q *devTriggerQueue) runCommand(command string) error {

--- a/apps/druid/adapters/cli/client/dev_test.go
+++ b/apps/druid/adapters/cli/client/dev_test.go
@@ -1,18 +1,22 @@
 package client
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gofiber/fiber/v2"
-	"github.com/highcard-dev/daemon/internal/core/domain"
+	"github.com/gorilla/websocket"
 	"github.com/highcard-dev/daemon/internal/core/ports"
+	coreservices "github.com/highcard-dev/daemon/internal/core/services"
 )
 
 func TestDevCommandExposesFlags(t *testing.T) {
@@ -31,7 +35,7 @@ func TestDevServerWebDAVReadWriteAndCallback(t *testing.T) {
 	if err := os.MkdirAll(filepath.Join(root, "data"), 0755); err != nil {
 		t.Fatal(err)
 	}
-	runCalls := 0
+	runCalls := make(chan struct{}, 4)
 	daemon := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/api/v1/scrolls/smoke/commands/build" {
 			t.Fatalf("unexpected daemon path %s", r.URL.Path)
@@ -39,7 +43,7 @@ func TestDevServerWebDAVReadWriteAndCallback(t *testing.T) {
 		if r.Header.Get("Authorization") != "Bearer secret" {
 			t.Fatalf("missing daemon token")
 		}
-		runCalls++
+		runCalls <- struct{}{}
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte(`{"id":"smoke"}`))
 	}))
@@ -56,9 +60,22 @@ func TestDevServerWebDAVReadWriteAndCallback(t *testing.T) {
 		devDaemonURL, devDaemonTokenFile, devRuntimeID = oldURL, oldTokenFile, oldRuntimeID
 	})
 
-	broadcast := domain.NewHub()
-	go broadcast.Run()
-	app := newDevApp(root, broadcast, &devTriggerQueue{broadcast: broadcast, commands: []string{"build"}})
+	queue := &devTriggerQueue{}
+	watch := coreservices.NewDevService(queue, devScrollService{commands: []string{"build"}})
+	if err := watch.SetHotReloadCommands([]string{"build"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := watch.StartWatching(root, "private"); err != nil {
+		t.Fatal(err)
+	}
+	defer watch.StopWatching()
+	// Starting Developer Mode always builds once before it begins watching edits.
+	select {
+	case <-runCalls:
+	case <-time.After(time.Second):
+		t.Fatal("initial build did not run")
+	}
+	app := newDevApp(root, watch)
 
 	req := httptest.NewRequest(http.MethodPut, "/webdav/private/config.json", strings.NewReader(`{"ok":true}`))
 	res, err := app.Test(req)
@@ -68,8 +85,10 @@ func TestDevServerWebDAVReadWriteAndCallback(t *testing.T) {
 	if res.StatusCode != http.StatusNoContent && res.StatusCode != http.StatusCreated {
 		t.Fatalf("PUT status = %d", res.StatusCode)
 	}
-	if runCalls != 1 {
-		t.Fatalf("runCalls = %d, want 1", runCalls)
+	select {
+	case <-runCalls:
+	case <-time.After(time.Second):
+		t.Fatal("file change did not run a rebuild")
 	}
 	if got, err := os.ReadFile(filepath.Join(root, "private/config.json")); err != nil || string(got) != `{"ok":true}` {
 		t.Fatalf("written file = %q, err = %v", got, err)
@@ -151,6 +170,79 @@ func TestDevServerWebDAVReadWriteAndCallback(t *testing.T) {
 	}
 }
 
+func TestDevServerWebsocketReceivesWatcherBuildEvents(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "private", "src"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	builds := make(chan struct{}, 4)
+	daemon := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		builds <- struct{}{}
+		_, _ = w.Write([]byte(`{"id":"smoke"}`))
+	}))
+	defer daemon.Close()
+	oldURL, oldTokenFile, oldRuntimeID := devDaemonURL, devDaemonTokenFile, devRuntimeID
+	devDaemonURL, devDaemonTokenFile, devRuntimeID = daemon.URL, "", "smoke"
+	t.Cleanup(func() {
+		devDaemonURL, devDaemonTokenFile, devRuntimeID = oldURL, oldTokenFile, oldRuntimeID
+	})
+
+	queue := &devTriggerQueue{}
+	watch := coreservices.NewDevService(queue, devScrollService{commands: []string{"build"}})
+	if err := watch.SetHotReloadCommands([]string{"build"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := watch.StartWatching(root, "private/src"); err != nil {
+		t.Fatal(err)
+	}
+	defer watch.StopWatching()
+	select {
+	case <-builds:
+	case <-time.After(time.Second):
+		t.Fatal("initial build did not run")
+	}
+
+	app := newDevApp(root, watch)
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+	go func() { _ = app.Listener(listener) }()
+	defer app.Shutdown()
+
+	ws, _, err := websocket.DefaultDialer.Dial("ws://"+listener.Addr().String()+"/ws/v1/watch/notify", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ws.Close()
+	if err := os.WriteFile(filepath.Join(root, "private", "src", "app.tsx"), []byte("export {}"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if err := ws.SetReadDeadline(deadline); err != nil {
+			t.Fatal(err)
+		}
+		_, data, err := ws.ReadMessage()
+		if err != nil {
+			t.Fatal(err)
+		}
+		var event struct {
+			CommandKey string `json:"command_key"`
+		}
+		if err := json.Unmarshal(data, &event); err != nil {
+			continue
+		}
+		if event.CommandKey == "build-ended" {
+			return
+		}
+	}
+	t.Fatal("websocket did not receive build-ended")
+}
+
 func TestDevFilePathRejectsTraversal(t *testing.T) {
 	if _, err := devFilePath(t.TempDir(), "../escape"); err == nil {
 		t.Fatal("expected traversal to be rejected")
@@ -159,9 +251,12 @@ func TestDevFilePathRejectsTraversal(t *testing.T) {
 
 func TestDevServerFileAuth(t *testing.T) {
 	root := t.TempDir()
-	broadcast := domain.NewHub()
-	go broadcast.Run()
-	app := newDevApp(root, broadcast, &devTriggerQueue{broadcast: broadcast}, devAuth{
+	watch := coreservices.NewDevService(&devTriggerQueue{}, devScrollService{})
+	if err := watch.StartWatching(root, "."); err != nil {
+		t.Fatal(err)
+	}
+	defer watch.StopWatching()
+	app := newDevApp(root, watch, devAuth{
 		user:      devTestAuth{},
 		runtime:   devTestAuth{},
 		runtimeID: "smoke",

--- a/internal/core/services/watch_service.go
+++ b/internal/core/services/watch_service.go
@@ -123,7 +123,7 @@ func (uds *WatchService) StartWatching(basePath string, paths ...string) error {
 	}
 
 	// Start the event processing goroutine
-	go uds.processEvents()
+	go uds.processEvents(uds.ctx, watcher)
 
 	// Start the broadcast hub
 	go uds.broadcastChannel.Run()
@@ -244,7 +244,7 @@ func (uds *WatchService) addWatchPath(path string) error {
 }
 
 // processEvents handles file system events and broadcasts them to subscribers
-func (uds *WatchService) processEvents() {
+func (uds *WatchService) processEvents(ctx context.Context, watcher *fsnotify.Watcher) {
 	defer func() {
 		if r := recover(); r != nil {
 			logger.Log().Error("File watcher panic recovered", zap.Any("error", r))
@@ -253,11 +253,11 @@ func (uds *WatchService) processEvents() {
 
 	for {
 		select {
-		case <-uds.ctx.Done():
+		case <-ctx.Done():
 			logger.Log().Info("File watcher context cancelled")
 			return
 
-		case event, ok := <-uds.watcher.Events:
+		case event, ok := <-watcher.Events:
 			if !ok {
 				logger.Log().Info("File watcher events channel closed")
 				return
@@ -268,7 +268,7 @@ func (uds *WatchService) processEvents() {
 			}
 			uds.handleFileEvent(event)
 
-		case err, ok := <-uds.watcher.Errors:
+		case err, ok := <-watcher.Errors:
 			if !ok {
 				logger.Log().Info("File watcher errors channel closed")
 				return


### PR DESCRIPTION
## Summary\n- deliver Developer Mode WebSocket events from the file watcher that owns builds\n- remove the unused duplicate dev event hub and duplicate WebDAV triggers\n- fix watcher shutdown ownership race and cover the complete WebSocket build-ended path\n\n## Validation\n- go test ./...\n- go test -race ./apps/druid/adapters/cli/client ./internal/core/services