### PR TITLE
Bind Druid UI publish jobs to verified digests

### DIFF
--- a/apps/druid/adapters/cli/daemon.go
+++ b/apps/druid/adapters/cli/daemon.go
@@ -283,7 +283,12 @@ func workloadIdentityMiddleware(authenticator ports.RuntimeWorkloadAuthenticator
 			return c.Next()
 		}
 		if allowUnsafe {
-			c.Locals("druid-workload-identity", ports.RuntimeWorkloadIdentity{Kind: "dev", RuntimeID: strings.TrimSpace(c.Get("X-Druid-Runtime-ID")), PodUID: "unsafe-local"})
+			runtimeID := strings.TrimSpace(c.Get("X-Druid-Runtime-ID"))
+			kind := "dev"
+			if isUIPackagePreparePath(c.Path(), runtimeID) {
+				kind = "ui-publish"
+			}
+			c.Locals("druid-workload-identity", ports.RuntimeWorkloadIdentity{Kind: kind, RuntimeID: runtimeID, PodUID: "unsafe-local"})
 			return c.Next()
 		}
 		if authenticator == nil {
@@ -302,12 +307,25 @@ func workloadIdentityMiddleware(authenticator ports.RuntimeWorkloadAuthenticator
 			c.Locals("druid-workload-identity", identity)
 			return c.Next()
 		}
+		if identity.Kind == "ui-publish" && c.Method() == fiber.MethodPost && isUIPackagePreparePath(c.Path(), identity.RuntimeID) {
+			c.Locals("druid-workload-identity", identity)
+			return c.Next()
+		}
 		if identity.Kind == "worker" && strings.HasPrefix(c.Path(), "/internal/v1/workers/"+identity.RuntimeID+"/") {
 			c.Locals("druid-workload-identity", identity)
 			return c.Next()
 		}
 		return fiber.NewError(fiber.StatusForbidden, "workload identity is not authorized for this request")
 	}
+}
+
+func isUIPackagePreparePath(requestPath string, runtimeID string) bool {
+	prefix := "/api/v1/scrolls/" + runtimeID + "/ui/packages/"
+	if runtimeID == "" || !strings.HasPrefix(requestPath, prefix) {
+		return false
+	}
+	parts := strings.Split(strings.TrimPrefix(requestPath, prefix), "/")
+	return len(parts) == 2 && (parts[0] == "private" || parts[0] == "public") && parts[1] == "prepare"
 }
 
 func openWorkerCallbackListener(listen string) (net.Listener, error) {

--- a/apps/druid/adapters/cli/root_test.go
+++ b/apps/druid/adapters/cli/root_test.go
@@ -16,6 +16,23 @@ func TestRootCommandExposesRuntimeAndOCICommands(t *testing.T) {
 	}
 }
 
+func TestUIPackagePreparePathRequiresExactRuntimeAndScope(t *testing.T) {
+	for _, test := range []struct {
+		path string
+		want bool
+	}{
+		{"/api/v1/scrolls/runtime-a/ui/packages/private/prepare", true},
+		{"/api/v1/scrolls/runtime-a/ui/packages/public/prepare", true},
+		{"/api/v1/scrolls/runtime-b/ui/packages/private/prepare", false},
+		{"/api/v1/scrolls/runtime-a/ui/packages/private/prepare/extra", false},
+		{"/api/v1/scrolls/runtime-a/ui/packages/admin/prepare", false},
+	} {
+		if got := isUIPackagePreparePath(test.path, "runtime-a"); got != test.want {
+			t.Fatalf("isUIPackagePreparePath(%q) = %t, want %t", test.path, got, test.want)
+		}
+	}
+}
+
 func TestDaemonCommandExposesRuntimeListeners(t *testing.T) {
 	for _, name := range []string{"tcp", "port"} {
 		if flag := DaemonCommand.Flags().Lookup(name); flag != nil {

--- a/apps/druid/adapters/http/handlers/routes.go
+++ b/apps/druid/adapters/http/handlers/routes.go
@@ -44,6 +44,7 @@ func RegisterManagementRoutes(app *fiber.App, handlers RouteHandlers) {
 	app.Get("/api/v1/scrolls/:id/dev/status", handlers.Server.GetDaemonWatchStatus)
 	app.Post("/api/v1/scrolls/:id/dev/enable", handlers.Server.EnableDaemonWatch)
 	app.Post("/api/v1/scrolls/:id/dev/disable", handlers.Server.DisableDaemonWatch)
+	app.Post("/api/v1/scrolls/:id/ui/packages/:scope/prepare", handlers.Server.PrepareDaemonUIPackageUpload)
 }
 
 func RegisterPublicRoutes(app *fiber.App, handlers RouteHandlers) {

--- a/apps/druid/adapters/http/handlers/scroll_handler.go
+++ b/apps/druid/adapters/http/handlers/scroll_handler.go
@@ -388,6 +388,20 @@ func (h *ScrollHandler) PublishDaemonUIPackage(c *fiber.Ctx) error {
 	return h.PublishScrollUIPackage(c, c.Params("id"), api.PublishScrollUIPackageParamsScope(c.Params("scope")))
 }
 
+func (h *ScrollHandler) PrepareDaemonUIPackageUpload(c *fiber.Ctx) error {
+	identity, ok := c.Locals("druid-workload-identity").(ports.RuntimeWorkloadIdentity)
+	if !ok || identity.Kind != "ui-publish" || identity.RuntimeID != c.Params("id") {
+		return fiber.NewError(fiber.StatusForbidden, "UI publish workload identity is not authorized")
+	}
+	url, err := h.supervisor.PrepareUIPackageUpload(
+		c.Params("id"), c.Params("scope"), c.FormValue("request_id"), c.FormValue("sha256"), c.FormValue("content_md5"),
+	)
+	if err != nil {
+		return err
+	}
+	return c.SendString(url)
+}
+
 func (h *ScrollHandler) BackupScroll(c *fiber.Ctx, id string) error {
 	if _, err := h.getScroll(id); err != nil {
 		return err

--- a/apps/druid/core/services/runtime_supervisor.go
+++ b/apps/druid/core/services/runtime_supervisor.go
@@ -28,8 +28,9 @@ type RuntimeSupervisor struct {
 	runtimeJWKSURL    string
 	workerTimeout     time.Duration
 
-	mu       sync.Mutex
-	sessions map[string]*RuntimeSession
+	mu          sync.Mutex
+	sessions    map[string]*RuntimeSession
+	uiPublishes map[string]ports.RuntimeUIPackageUploadAction
 }
 
 func NewRuntimeSupervisor(
@@ -43,6 +44,7 @@ func NewRuntimeSupervisor(
 		runtimeBackend: runtimeBackend,
 		workerTimeout:  20 * time.Minute,
 		sessions:       map[string]*RuntimeSession{},
+		uiPublishes:    map[string]ports.RuntimeUIPackageUploadAction{},
 	}
 }
 

--- a/apps/druid/core/services/runtime_ui.go
+++ b/apps/druid/core/services/runtime_ui.go
@@ -2,6 +2,8 @@ package services
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/hex"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -11,6 +13,41 @@ import (
 	"github.com/highcard-dev/daemon/internal/core/domain"
 	"github.com/highcard-dev/daemon/internal/core/ports"
 )
+
+// PrepareUIPackageUpload binds a one-shot S3 capability to digests calculated
+// by the authenticated publish Job. The pending request was created by the
+// owner-authorized publish action and is removed when that action completes.
+func (s *RuntimeSupervisor) PrepareUIPackageUpload(id string, scope string, requestID string, sha256 string, contentMD5 string) (string, error) {
+	uiScope, _, err := normalizeUIPackageRequest(scope, "")
+	if err != nil {
+		return "", err
+	}
+	if sum, err := hex.DecodeString(sha256); err != nil || len(sum) != 32 {
+		return "", fmt.Errorf("invalid UI package SHA-256")
+	}
+	if sum, err := base64.StdEncoding.DecodeString(contentMD5); err != nil || len(sum) != 16 {
+		return "", fmt.Errorf("invalid UI package Content-MD5")
+	}
+	s.mu.Lock()
+	action, ok := s.uiPublishes[requestID]
+	if !ok || action.RuntimeID != id || action.Scope != uiScope || action.SHA256 != "" || action.ContentMD5 != "" {
+		s.mu.Unlock()
+		return "", fmt.Errorf("unknown or already prepared UI package upload")
+	}
+	action.SHA256 = sha256
+	action.ContentMD5 = contentMD5
+	s.uiPublishes[requestID] = action
+	s.mu.Unlock()
+
+	url, err := s.runtimeBackend.PrepareUIPackageUpload(context.Background(), action)
+	if err != nil {
+		s.mu.Lock()
+		delete(s.uiPublishes, requestID)
+		s.mu.Unlock()
+		return "", err
+	}
+	return url, nil
+}
 
 const (
 	defaultPrivateUIPackagePath = "private/dist/app.wasm"
@@ -30,6 +67,9 @@ func (s *RuntimeSupervisor) PublishUIPackage(id string, scope string, sourcePath
 	if err != nil {
 		return nil, err
 	}
+	if s.workerDaemonURL == "" {
+		return nil, fmt.Errorf("Druid UI publishing requires a configured runtime management URL")
+	}
 	status, err := s.runtimeBackend.DevStatus(context.Background(), runtimeScroll.Root)
 	if err != nil {
 		return nil, err
@@ -44,10 +84,14 @@ func (s *RuntimeSupervisor) PublishUIPackage(id string, scope string, sourcePath
 		Scope:     uiScope,
 		RequestID: uuid.NewString(),
 	}
-	uploadURL, err := s.runtimeBackend.PrepareUIPackageUpload(context.Background(), action)
-	if err != nil {
-		return nil, err
-	}
+	s.mu.Lock()
+	s.uiPublishes[action.RequestID] = action
+	s.mu.Unlock()
+	defer func() {
+		s.mu.Lock()
+		delete(s.uiPublishes, action.RequestID)
+		s.mu.Unlock()
+	}()
 
 	commandName := "ui_publish_" + string(uiScope)
 	command := uiPublishCommand()
@@ -61,13 +105,20 @@ func (s *RuntimeSupervisor) PublishUIPackage(id string, scope string, sourcePath
 	procedureName := domain.ProcedureName(commandName, 0, command.Procedures[0])
 	if err := session.AddTempItemWithWaitEnv(commandName, map[string]map[string]string{
 		procedureName: {
-			"DRUID_UI_SOURCE":     sourcePath,
-			"DRUID_UI_UPLOAD_URL": uploadURL,
+			"DRUID_UI_SOURCE":      sourcePath,
+			"DRUID_UI_REQUEST_ID":  action.RequestID,
+			"DRUID_UI_PREPARE_URL": strings.TrimRight(s.workerDaemonURL, "/") + "/api/v1/scrolls/" + runtimeScroll.ID + "/ui/packages/" + string(uiScope) + "/prepare",
 		},
 	}); err != nil {
 		return nil, err
 	}
 
+	s.mu.Lock()
+	action = s.uiPublishes[action.RequestID]
+	s.mu.Unlock()
+	if action.SHA256 == "" || action.ContentMD5 == "" {
+		return nil, fmt.Errorf("Druid UI publish job did not request its digest-bound upload URL")
+	}
 	result, err := s.runtimeBackend.CompleteUIPackageUpload(context.Background(), action)
 	if err != nil {
 		return nil, fmt.Errorf("verify uploaded UI package: %w", err)
@@ -97,15 +148,29 @@ func uiPublishCommand() *domain.CommandInstructionSet {
 			Mounts:     []domain.Mount{{Path: "/app/resources/deployment"}},
 			Command: []string{"sh", "-ec", `
 source="${DRUID_UI_SOURCE:?DRUID_UI_SOURCE is required}"
-url="${DRUID_UI_UPLOAD_URL:?DRUID_UI_UPLOAD_URL is required}"
+prepare_url="${DRUID_UI_PREPARE_URL:?DRUID_UI_PREPARE_URL is required}"
+request_id="${DRUID_UI_REQUEST_ID:?DRUID_UI_REQUEST_ID is required}"
+token_file="${DRUID_UI_TOKEN_FILE:-/var/run/secrets/druid-cli/token}"
 case "$source" in private/*.wasm|public/*.wasm) ;; *) echo "invalid UI package path" >&2; exit 1;; esac
 test -f "$source" && test -s "$source"
-checksum="$(sha256sum "$source" | awk '{print $1}' | xxd -r -p | base64 -w 0)"
+artifact="$(mktemp)"
+trap 'rm -f "$artifact"' EXIT
+cp "$source" "$artifact"
+source="$artifact"
+sha256="$(sha256sum "$source" | awk '{print $1}')"
+content_md5="$(md5sum "$source" | awk '{print $1}' | xxd -r -p | base64 | tr -d '\n')"
+url="$(curl --fail --silent --show-error --request POST \
+  --header "Authorization: Bearer $(cat "$token_file")" \
+  --data-urlencode "request_id=$request_id" \
+  --data-urlencode "sha256=$sha256" \
+  --data-urlencode "content_md5=$content_md5" \
+  "$prepare_url")"
 curl --fail --silent --show-error --request PUT --upload-file "$source" \
   --header "Content-Type: application/wasm" \
   --header "Cache-Control: public, max-age=31536000, immutable" \
   --header "x-amz-sdk-checksum-algorithm: SHA256" \
-  --header "x-amz-checksum-sha256: $checksum" \
+  --header "x-amz-checksum-sha256: $(printf '%s' "$sha256" | xxd -r -p | base64 | tr -d '\n')" \
+  --header "Content-MD5: $content_md5" \
   "$url"
 `},
 		}},

--- a/apps/druid/core/services/runtime_ui_test.go
+++ b/apps/druid/core/services/runtime_ui_test.go
@@ -48,11 +48,18 @@ func TestPublishUIPackageRunsOneShotCommandWithEphemeralURL(t *testing.T) {
 		t.Fatal(err)
 	}
 	var command ports.RuntimeCommand
+	var supervisor *RuntimeSupervisor
 	backend := &fakeWorkerBackend{runCommand: func(got ports.RuntimeCommand) (*int, error) {
 		command = got
+		procedure := domain.ProcedureName(got.Name, 0, got.Command.Procedures[0])
+		values := got.ProcedureEnv[procedure]
+		if _, err := supervisor.PrepareUIPackageUpload("ui-scroll", "private", values["DRUID_UI_REQUEST_ID"], strings.Repeat("a", 64), "AAAAAAAAAAAAAAAAAAAAAA=="); err != nil {
+			return nil, err
+		}
 		return nil, nil
 	}}
-	supervisor := NewRuntimeSupervisor(store, coreservices.NewRuntimeScrollManager(store), backend)
+	supervisor = NewRuntimeSupervisor(store, coreservices.NewRuntimeScrollManager(store), backend)
+	supervisor.SetDevWorkerConfig("http://daemon", "", "")
 
 	updated, err := supervisor.PublishUIPackage("ui-scroll", "private", "")
 	if err != nil {
@@ -69,10 +76,10 @@ func TestPublishUIPackageRunsOneShotCommandWithEphemeralURL(t *testing.T) {
 	}
 	procedure := domain.ProcedureName(command.Name, 0, command.Command.Procedures[0])
 	values := command.ProcedureEnv[procedure]
-	if values["DRUID_UI_SOURCE"] != "private/dist/app.wasm" || !strings.HasPrefix(values["DRUID_UI_UPLOAD_URL"], "http://uploads/ui-scroll/private") {
+	if values["DRUID_UI_SOURCE"] != "private/dist/app.wasm" || values["DRUID_UI_REQUEST_ID"] == "" || values["DRUID_UI_PREPARE_URL"] != "http://daemon/api/v1/scrolls/ui-scroll/ui/packages/private/prepare" {
 		t.Fatalf("procedure env = %#v", values)
 	}
-	if strings.Contains(strings.Join(command.Command.Procedures[0].Command, " "), values["DRUID_UI_UPLOAD_URL"]) {
+	if strings.Contains(strings.Join(command.Command.Procedures[0].Command, " "), "http://uploads/") {
 		t.Fatal("upload URL must not be persisted in command arguments")
 	}
 }

--- a/internal/core/ports/services_ports.go
+++ b/internal/core/ports/services_ports.go
@@ -116,10 +116,12 @@ func (c RuntimeCommand) ObserveProcedureStatus(procedure string, status domain.S
 }
 
 type RuntimeUIPackageUploadAction struct {
-	RuntimeID string
-	RootRef   string
-	Scope     domain.RuntimeUIPackageScope
-	RequestID string
+	RuntimeID  string
+	RootRef    string
+	Scope      domain.RuntimeUIPackageScope
+	RequestID  string
+	SHA256     string
+	ContentMD5 string
 }
 
 type RuntimeUIPackageResult struct {

--- a/internal/runtime/docker/ui.go
+++ b/internal/runtime/docker/ui.go
@@ -14,7 +14,7 @@ func (b *Backend) PrepareUIPackageUpload(ctx context.Context, action ports.Runti
 	if err := b.config.ValidateForUIPublishing(); err != nil {
 		return "", err
 	}
-	return uipackage.PresignPut(ctx, uiPackageObjectName(action), b.uiPackageS3Config(action))
+	return uipackage.PresignPut(ctx, uiPackageObjectName(action), action, b.uiPackageS3Config(action))
 }
 
 func (b *Backend) CompleteUIPackageUpload(ctx context.Context, action ports.RuntimeUIPackageUploadAction) (ports.RuntimeUIPackageResult, error) {
@@ -23,7 +23,7 @@ func (b *Backend) CompleteUIPackageUpload(ctx context.Context, action ports.Runt
 	}
 	config := b.uiPackageS3Config(action)
 	objectName := uiPackageObjectName(action)
-	sha256, err := uipackage.Inspect(ctx, objectName, config)
+	sha256, err := uipackage.Inspect(ctx, objectName, action, config)
 	if err != nil {
 		return ports.RuntimeUIPackageResult{}, fmt.Errorf("verify uploaded UI package: %w", err)
 	}

--- a/internal/runtime/kubernetes/procedure_attempts.go
+++ b/internal/runtime/kubernetes/procedure_attempts.go
@@ -134,7 +134,7 @@ func (b *Backend) createOrReuseProcedureJob(ctx context.Context, namespace strin
 		return active, nil
 	}
 	name := procedureAttemptName(baseName, nextAttempt)
-	job, err := procedureJobSpec(namespace, root, commandName, procedureName, name, nextAttempt, procedure, env, b.config.RegistrySecret)
+	job, err := procedureJobSpec(namespace, root, commandName, procedureName, name, nextAttempt, procedure, env, b.config.RegistrySecret, b.config.ServiceAccountAudience)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/runtime/kubernetes/resources.go
+++ b/internal/runtime/kubernetes/resources.go
@@ -179,7 +179,7 @@ func helperJobSpec(namespace string, jobName string, pvc string, image string, c
 	}
 }
 
-func procedureJobSpec(namespace string, root string, commandName string, procedureName string, resourceName string, attempt int, procedure *domain.Procedure, env map[string]string, registrySecret string) (*batchv1.Job, error) {
+func procedureJobSpec(namespace string, root string, commandName string, procedureName string, resourceName string, attempt int, procedure *domain.Procedure, env map[string]string, registrySecret string, tokenAudience string) (*batchv1.Job, error) {
 	_, pvc, err := parseRef(root)
 	if err != nil {
 		return nil, err
@@ -208,6 +208,13 @@ func procedureJobSpec(namespace string, root string, commandName string, procedu
 		RestartPolicy: corev1.RestartPolicyNever,
 		Containers:    []corev1.Container{container},
 		Volumes:       []corev1.Volume{pvcVolume("data", pvc)},
+	}
+	if commandName == "ui_publish_private" || commandName == "ui_publish_public" {
+		podSpec.ServiceAccountName = runtimeDevServiceAccount
+		podSpec.AutomountServiceAccountToken = ptrBool(false)
+		volumes, mounts := workloadTokenVolume(tokenAudience)
+		podSpec.Volumes = append(podSpec.Volumes, volumes...)
+		podSpec.Containers[0].VolumeMounts = append(podSpec.Containers[0].VolumeMounts, mounts...)
 	}
 	if registrySecret != "" {
 		podSpec.ImagePullSecrets = []corev1.LocalObjectReference{{Name: registrySecret}}

--- a/internal/runtime/kubernetes/resources_test.go
+++ b/internal/runtime/kubernetes/resources_test.go
@@ -95,7 +95,7 @@ func TestProcedureJobSpecBuildsDeterministicMountsAndLabels(t *testing.T) {
 		Mounts: []domain.Mount{{Path: "/work", SubPath: "cache"}},
 	}
 
-	job, err := procedureJobSpec("druid", ref("druid", "druid-static-web-data"), "start", "start", "static-web-start-0", 1, procedure, procedure.Env, "registry-secret")
+	job, err := procedureJobSpec("druid", ref("druid", "druid-static-web-data"), "start", "start", "static-web-start-0", 1, procedure, procedure.Env, "registry-secret", "druid-cli")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -198,7 +198,7 @@ func TestProcedureJobSpecUsesProvidedRuntimeEnv(t *testing.T) {
 	}
 	job, err := procedureJobSpec("druid", ref("druid", "druid-static-web-data"), "start", "start", "static-web-start-0", 1, procedure, map[string]string{
 		"DRUID_PORT_HTTP": "8080",
-	}, "registry-secret")
+	}, "registry-secret", "druid-cli")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -208,12 +208,35 @@ func TestProcedureJobSpecUsesProvidedRuntimeEnv(t *testing.T) {
 	}
 }
 
+func TestUIPublishProcedureJobUsesProjectedDevIdentity(t *testing.T) {
+	procedure := &domain.Procedure{Image: "curlimages/curl:8.12.1", Command: []string{"true"}}
+	job, err := procedureJobSpec("druid", ref("druid", "druid-ui-data"), "ui_publish_private", "ui_publish_private.0", "ui-publish-private-0", 1, procedure, nil, "registry-secret", "druid-cli")
+	if err != nil {
+		t.Fatal(err)
+	}
+	pod := job.Spec.Template.Spec
+	if pod.ServiceAccountName != runtimeDevServiceAccount || pod.AutomountServiceAccountToken == nil || *pod.AutomountServiceAccountToken {
+		t.Fatalf("publish pod identity = %#v", pod)
+	}
+	if len(pod.Volumes) != 2 || pod.Volumes[1].Projected == nil || len(pod.Volumes[1].Projected.Sources) != 1 {
+		t.Fatalf("publish pod volumes = %#v", pod.Volumes)
+	}
+	token := pod.Volumes[1].Projected.Sources[0].ServiceAccountToken
+	if token == nil || token.Audience != "druid-cli" || token.Path != "token" || token.ExpirationSeconds == nil || *token.ExpirationSeconds != 600 {
+		t.Fatalf("publish token projection = %#v", token)
+	}
+	mounts := pod.Containers[0].VolumeMounts
+	if len(mounts) != 1 || mounts[0].MountPath != "/var/run/secrets/druid-cli" || !mounts[0].ReadOnly {
+		t.Fatalf("publish token mount = %#v", mounts)
+	}
+}
+
 func TestProcedureJobSpecDoesNotAddReadinessProbe(t *testing.T) {
 	procedure := &domain.Procedure{
 		Image:         "itzg/minecraft-server",
 		ExpectedPorts: []domain.ExpectedPort{{Name: "main"}},
 	}
-	job, err := procedureJobSpec("druid", ref("druid", "druid-minecraft-data"), "start", "start", "minecraft-start-0", 1, procedure, nil, "registry-secret")
+	job, err := procedureJobSpec("druid", ref("druid", "druid-minecraft-data"), "start", "start", "minecraft-start-0", 1, procedure, nil, "registry-secret", "druid-cli")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/runtime/kubernetes/ui.go
+++ b/internal/runtime/kubernetes/ui.go
@@ -18,7 +18,7 @@ func (b *Backend) PrepareUIPackageUpload(ctx context.Context, action ports.Runti
 	if err != nil {
 		return "", err
 	}
-	return uipackage.PresignPut(ctx, uiPackageObjectName(action), b.uiPackageS3Config(namespace, action))
+	return uipackage.PresignPut(ctx, uiPackageObjectName(action), action, b.uiPackageS3Config(namespace, action))
 }
 
 func (b *Backend) CompleteUIPackageUpload(ctx context.Context, action ports.RuntimeUIPackageUploadAction) (ports.RuntimeUIPackageResult, error) {
@@ -31,7 +31,7 @@ func (b *Backend) CompleteUIPackageUpload(ctx context.Context, action ports.Runt
 	}
 	config := b.uiPackageS3Config(namespace, action)
 	objectName := uiPackageObjectName(action)
-	sha256, err := uipackage.Inspect(ctx, objectName, config)
+	sha256, err := uipackage.Inspect(ctx, objectName, action, config)
 	if err != nil {
 		return ports.RuntimeUIPackageResult{}, fmt.Errorf("verify uploaded UI package: %w", err)
 	}

--- a/internal/runtime/kubernetes/workload_identity.go
+++ b/internal/runtime/kubernetes/workload_identity.go
@@ -60,10 +60,16 @@ func (b *Backend) AuthenticateWorkload(ctx context.Context, token string) (ports
 	}
 	switch serviceAccount {
 	case runtimeDevServiceAccount:
-		if pod.Labels[labelManagedBy] != "druid" || pod.Labels[labelProcedure] != "dev" || identity.RuntimeID == "" {
+		if pod.Labels[labelManagedBy] != "druid" || identity.RuntimeID == "" {
 			return ports.RuntimeWorkloadIdentity{}, fmt.Errorf("invalid Druid dev workload")
 		}
-		identity.Kind = "dev"
+		if pod.Labels[labelProcedure] == "dev" {
+			identity.Kind = "dev"
+		} else if pod.Labels[labelProcedure] == "ui-publish-private-0" || pod.Labels[labelProcedure] == "ui-publish-public-0" {
+			identity.Kind = "ui-publish"
+		} else {
+			return ports.RuntimeWorkloadIdentity{}, fmt.Errorf("invalid Druid dev workload")
+		}
 	case runtimeWorkerServiceAccount:
 		if pod.Labels[labelManagedBy] != "druid" || pod.Labels[labelComponent] != "worker-pull" || identity.RuntimeID == "" {
 			return ports.RuntimeWorkloadIdentity{}, fmt.Errorf("invalid Druid worker workload")

--- a/internal/runtime/kubernetes/workload_identity_test.go
+++ b/internal/runtime/kubernetes/workload_identity_test.go
@@ -31,6 +31,38 @@ func TestAuthenticateWorkloadRequiresBoundDruidDevPod(t *testing.T) {
 	}
 }
 
+func TestAuthenticateWorkloadAcceptsOnlyDruidUIPublishJob(t *testing.T) {
+	client := k8sfake.NewSimpleClientset(&corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "publish-0", Namespace: "games", UID: types.UID("pod-uid"), Labels: map[string]string{
+			labelManagedBy: "druid", labelRuntimeID: "runtime-a", labelCommand: "ui-publish-private", labelProcedure: "ui-publish-private-0",
+		}},
+		Spec: corev1.PodSpec{ServiceAccountName: runtimeDevServiceAccount},
+	})
+	client.PrependReactor("create", "tokenreviews", tokenReviewReactor(runtimeDevServiceAccount, "games", "publish-0", "pod-uid", true))
+	backend := NewWithClient(Config{Namespace: "games", OperatorServiceAccount: "operator-system/operator"}, nil, client)
+	identity, err := backend.AuthenticateWorkload(context.Background(), "token")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if identity.Kind != "ui-publish" || identity.RuntimeID != "runtime-a" {
+		t.Fatalf("identity = %#v", identity)
+	}
+}
+
+func TestAuthenticateWorkloadRejectsUnrelatedDevServiceAccountPod(t *testing.T) {
+	client := k8sfake.NewSimpleClientset(&corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "other-0", Namespace: "games", UID: types.UID("pod-uid"), Labels: map[string]string{
+			labelManagedBy: "druid", labelRuntimeID: "runtime-a", labelCommand: "ui-publish-private", labelProcedure: "different-procedure",
+		}},
+		Spec: corev1.PodSpec{ServiceAccountName: runtimeDevServiceAccount},
+	})
+	client.PrependReactor("create", "tokenreviews", tokenReviewReactor(runtimeDevServiceAccount, "games", "other-0", "pod-uid", true))
+	backend := NewWithClient(Config{Namespace: "games", OperatorServiceAccount: "operator-system/operator"}, nil, client)
+	if _, err := backend.AuthenticateWorkload(context.Background(), "token"); err == nil {
+		t.Fatal("unrelated Druid dev service account pod was accepted")
+	}
+}
+
 func TestAuthenticateWorkloadRejectsWrongAudienceOrDeletedPod(t *testing.T) {
 	client := k8sfake.NewSimpleClientset()
 	client.PrependReactor("create", "tokenreviews", tokenReviewReactor(runtimeWorkerServiceAccount, "games", "worker-0", "pod-uid", false))

--- a/internal/uipackage/publish.go
+++ b/internal/uipackage/publish.go
@@ -6,15 +6,19 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"fmt"
+	"net/http"
+	"net/url"
 	"path"
 	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/aws/signer/v4"
 	awscfg "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/highcard-dev/daemon/internal/core/ports"
 )
 
 type S3Config struct {
@@ -28,13 +32,21 @@ type S3Config struct {
 	VerifyEndpoint string
 }
 
-func newClient(ctx context.Context, config S3Config) (*s3.Client, error) {
+func loadConfig(ctx context.Context, config S3Config) (aws.Config, error) {
 	cfg, err := awscfg.LoadDefaultConfig(ctx, awscfg.WithRegion(config.Region))
 	if err != nil {
-		return nil, err
+		return aws.Config{}, err
 	}
 	if config.AccessKey != "" || config.SecretKey != "" {
 		cfg.Credentials = aws.NewCredentialsCache(credentials.NewStaticCredentialsProvider(config.AccessKey, config.SecretKey, config.SessionToken))
+	}
+	return cfg, nil
+}
+
+func newClient(ctx context.Context, config S3Config) (*s3.Client, error) {
+	cfg, err := loadConfig(ctx, config)
+	if err != nil {
+		return nil, err
 	}
 	return s3.NewFromConfig(cfg, func(options *s3.Options) {
 		if config.Endpoint != "" {
@@ -44,33 +56,77 @@ func newClient(ctx context.Context, config S3Config) (*s3.Client, error) {
 	}), nil
 }
 
+func objectURL(config S3Config, objectName string) (*url.URL, error) {
+	key := path.Join(strings.Trim(config.KeyPrefix, "/"), objectName)
+	endpoint := config.Endpoint
+	if endpoint == "" {
+		endpoint = "https://" + config.Bucket + ".s3." + config.Region + ".amazonaws.com"
+	} else {
+		key = path.Join(config.Bucket, key)
+	}
+	parsed, err := url.Parse(endpoint)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return nil, fmt.Errorf("invalid UI package S3 endpoint")
+	}
+	parsed.Path = path.Join(parsed.Path, key)
+	return parsed, nil
+}
+
 // PresignPut issues a short-lived URL for a one-shot runtime command.
 // S3 requires the uploader to provide a SHA-256 checksum and verifies it
 // against the uploaded bytes before accepting the object.
-func PresignPut(ctx context.Context, objectName string, config S3Config) (string, error) {
-	if config.Bucket == "" || config.Region == "" || objectName == "" {
-		return "", fmt.Errorf("ui package S3 bucket, region, and object name are required")
+func PresignPut(ctx context.Context, objectName string, action ports.RuntimeUIPackageUploadAction, config S3Config) (string, error) {
+	if config.Bucket == "" || config.Region == "" || objectName == "" || action.SHA256 == "" || action.ContentMD5 == "" {
+		return "", fmt.Errorf("ui package S3 bucket, region, object name, and digests are required")
 	}
-	client, err := newClient(ctx, config)
+	sha256sum, err := hex.DecodeString(action.SHA256)
+	if err != nil || len(sha256sum) != sha256.Size {
+		return "", fmt.Errorf("invalid UI package SHA-256")
+	}
+	md5, err := base64.StdEncoding.DecodeString(action.ContentMD5)
+	if err != nil || len(md5) != 16 {
+		return "", fmt.Errorf("invalid UI package Content-MD5")
+	}
+	cfg, err := loadConfig(ctx, config)
 	if err != nil {
 		return "", err
 	}
-	request, err := s3.NewPresignClient(client).PresignPutObject(ctx, &s3.PutObjectInput{
-		Bucket:            aws.String(config.Bucket),
-		Key:               aws.String(path.Join(strings.Trim(config.KeyPrefix, "/"), objectName)),
-		ContentType:       aws.String("application/wasm"),
-		CacheControl:      aws.String("public, max-age=31536000, immutable"),
-		ChecksumAlgorithm: types.ChecksumAlgorithmSha256,
-	}, s3.WithPresignExpires(5*time.Minute))
+	uploadURL, err := objectURL(config, objectName)
 	if err != nil {
 		return "", err
 	}
-	return request.URL, nil
+	query := uploadURL.Query()
+	query.Set("X-Amz-Expires", "300")
+	uploadURL.RawQuery = query.Encode()
+	request, err := http.NewRequestWithContext(ctx, http.MethodPut, uploadURL.String(), nil)
+	if err != nil {
+		return "", err
+	}
+	checksum := base64.StdEncoding.EncodeToString(sha256sum)
+	request.Header.Set("Content-Type", "application/wasm")
+	request.Header.Set("Cache-Control", "public, max-age=31536000, immutable")
+	request.Header.Set("Content-MD5", action.ContentMD5)
+	request.Header.Set("x-amz-sdk-checksum-algorithm", "SHA256")
+	request.Header.Set("x-amz-checksum-sha256", checksum)
+	credentials, err := cfg.Credentials.Retrieve(ctx)
+	if err != nil {
+		return "", err
+	}
+	presigned, signedHeaders, err := v4.NewSigner().PresignHTTP(ctx, credentials, request, "UNSIGNED-PAYLOAD", "s3", config.Region, time.Now(), func(options *v4.SignerOptions) {
+		options.DisableHeaderHoisting = true
+	})
+	if err != nil {
+		return "", err
+	}
+	if signedHeaders.Get("Content-Md5") != action.ContentMD5 || signedHeaders.Get("X-Amz-Checksum-Sha256") != checksum || signedHeaders.Get("X-Amz-Sdk-Checksum-Algorithm") != "SHA256" {
+		return "", fmt.Errorf("UI package presigned request did not bind required integrity headers")
+	}
+	return presigned, nil
 }
 
 // Inspect returns the checksum verified by the object store. A
 // package without a server-returned SHA-256 checksum is never published.
-func Inspect(ctx context.Context, objectName string, config S3Config) (string, error) {
+func Inspect(ctx context.Context, objectName string, action ports.RuntimeUIPackageUploadAction, config S3Config) (string, error) {
 	if config.VerifyEndpoint != "" {
 		config.Endpoint = config.VerifyEndpoint
 	}
@@ -88,6 +144,13 @@ func Inspect(ctx context.Context, objectName string, config S3Config) (string, e
 	}
 	if object.ContentLength == nil || *object.ContentLength <= 0 {
 		return "", fmt.Errorf("uploaded UI package is empty")
+	}
+	md5, err := base64.StdEncoding.DecodeString(action.ContentMD5)
+	if err != nil || len(md5) != 16 {
+		return "", fmt.Errorf("invalid expected UI package Content-MD5")
+	}
+	if object.ETag == nil || strings.Trim(*object.ETag, "\"") != hex.EncodeToString(md5) {
+		return "", fmt.Errorf("uploaded UI package ETag does not match the signed Content-MD5")
 	}
 	if object.ChecksumSHA256 == nil || *object.ChecksumSHA256 == "" {
 		return "", fmt.Errorf("uploaded UI package is missing a verified SHA-256 checksum")

--- a/internal/uipackage/publish_test.go
+++ b/internal/uipackage/publish_test.go
@@ -1,0 +1,54 @@
+package uipackage
+
+import (
+	"context"
+	"crypto/md5"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/highcard-dev/daemon/internal/core/domain"
+	"github.com/highcard-dev/daemon/internal/core/ports"
+)
+
+func TestPresignPutBindsContentDigests(t *testing.T) {
+	contents := []byte("Druid UI package")
+	sha256sum := sha256.Sum256(contents)
+	md5sum := md5.Sum(contents)
+	action := ports.RuntimeUIPackageUploadAction{
+		Scope:      domain.RuntimeUIPackageScopePrivate,
+		SHA256:     hex.EncodeToString(sha256sum[:]),
+		ContentMD5: base64.StdEncoding.EncodeToString(md5sum[:]),
+	}
+	presigned, err := PresignPut(context.Background(), "request/app.wasm", action, S3Config{
+		Bucket: "druid-ui", Region: "fsn1", Endpoint: "https://s3.example.test", AccessKey: "access", SecretKey: "secret",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	parsed, err := url.Parse(presigned)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := parsed.Query().Get("X-Amz-Expires"); got != "300" {
+		t.Fatalf("signature expiry = %q, want 300 seconds", got)
+	}
+	signedHeaders := parsed.Query().Get("X-Amz-SignedHeaders")
+	for _, header := range []string{"content-md5", "x-amz-checksum-sha256", "x-amz-sdk-checksum-algorithm"} {
+		if !strings.Contains(signedHeaders, header) {
+			t.Fatalf("signed headers = %q, missing %q", signedHeaders, header)
+		}
+	}
+}
+
+func TestPresignPutRejectsInvalidDigests(t *testing.T) {
+	_, err := PresignPut(context.Background(), "request/app.wasm", ports.RuntimeUIPackageUploadAction{
+		SHA256: "not-a-sha", ContentMD5: "not-an-md5",
+	}, S3Config{Bucket: "druid-ui", Region: "fsn1", AccessKey: "access", SecretKey: "secret"})
+	if err == nil {
+		t.Fatal("invalid digest action was accepted")
+	}
+}


### PR DESCRIPTION
## Summary\n- authenticate the one-shot Druid UI publish Job with its projected Kubernetes ServiceAccount token before issuing a presigned URL\n- bind the five-minute S3 capability to exact MD5 and SHA-256 headers, then verify object size, ETag, and returned SHA-256 before package metadata is persisted\n- restrict workload identity and prepare routes to the exact runtime/private-or-public scope, with explicit unsafe local Docker behavior only\n\n## Validation\n- ?   	github.com/highcard-dev/daemon/apps/druid	[no test files]
ok  	github.com/highcard-dev/daemon/apps/druid/adapters/cli	0.959s
ok  	github.com/highcard-dev/daemon/apps/druid/adapters/cli/client	(cached)
ok  	github.com/highcard-dev/daemon/apps/druid/adapters/daemonclient	(cached)
ok  	github.com/highcard-dev/daemon/apps/druid/adapters/http/handlers	(cached)
ok  	github.com/highcard-dev/daemon/apps/druid/adapters/websocketclient	(cached)
ok  	github.com/highcard-dev/daemon/apps/druid/core/services	(cached)
?   	github.com/highcard-dev/daemon/apps/druid-coldstarter	[no test files]
ok  	github.com/highcard-dev/daemon/apps/druid-coldstarter/adapters/cli	(cached)
ok  	github.com/highcard-dev/daemon/apps/druid-coldstarter/core/services	(cached)
ok  	github.com/highcard-dev/daemon/config/helm-charts/druid-cli	(cached)
?   	github.com/highcard-dev/daemon/debug	[no test files]
?   	github.com/highcard-dev/daemon/docs_md	[no test files]
?   	github.com/highcard-dev/daemon/internal	[no test files]
ok  	github.com/highcard-dev/daemon/internal/api	(cached)
?   	github.com/highcard-dev/daemon/internal/callbackapi	[no test files]
ok  	github.com/highcard-dev/daemon/internal/core/domain	(cached)
?   	github.com/highcard-dev/daemon/internal/core/ports	[no test files]
ok  	github.com/highcard-dev/daemon/internal/core/services	(cached)
?   	github.com/highcard-dev/daemon/internal/core/services/coldstarter/handler	[no test files]
?   	github.com/highcard-dev/daemon/internal/core/services/coldstarter/servers	[no test files]
ok  	github.com/highcard-dev/daemon/internal/core/services/registry	(cached)
?   	github.com/highcard-dev/daemon/internal/devapi	[no test files]
ok  	github.com/highcard-dev/daemon/internal/routing	(cached)
ok  	github.com/highcard-dev/daemon/internal/runtime	0.765s
ok  	github.com/highcard-dev/daemon/internal/runtime/docker	(cached)
ok  	github.com/highcard-dev/daemon/internal/runtime/kubernetes	(cached)
ok  	github.com/highcard-dev/daemon/internal/uipackage	0.207s
ok  	github.com/highcard-dev/daemon/internal/utils	(cached)
?   	github.com/highcard-dev/daemon/internal/utils/env	[no test files]
?   	github.com/highcard-dev/daemon/internal/utils/logger	[no test files]
?   	github.com/highcard-dev/daemon/test/integration/internal/e2e	[no test files]
?   	github.com/highcard-dev/daemon/test/mock	[no test files]
?   	github.com/highcard-dev/daemon/test/utils	[no test files]\n- ok  	github.com/highcard-dev/daemon/apps/druid/core/services	(cached)
ok  	github.com/highcard-dev/daemon/internal/runtime/kubernetes	(cached)
ok  	github.com/highcard-dev/daemon/apps/druid/adapters/cli	(cached)
ok  	github.com/highcard-dev/daemon/internal/uipackage	(cached)\n- \n- focused presigning and Kubernetes identity tests\n\nProduction verification will publish a disposable Developer Mode package after the release workflow deploys this change.