### PR TITLE
Fix persisted runtime command recovery

### DIFF
--- a/apps/druid/adapters/http/handlers/scroll_handler.go
+++ b/apps/druid/adapters/http/handlers/scroll_handler.go
@@ -393,13 +393,13 @@ func (h *ScrollHandler) PrepareDaemonUIPackageUpload(c *fiber.Ctx) error {
 	if !ok || identity.Kind != "ui-publish" || identity.RuntimeID != c.Params("id") {
 		return fiber.NewError(fiber.StatusForbidden, "UI publish workload identity is not authorized")
 	}
-	url, err := h.supervisor.PrepareUIPackageUpload(
+	capability, err := h.supervisor.PrepareUIPackageUpload(
 		c.Params("id"), c.Params("scope"), c.FormValue("request_id"), c.FormValue("sha256"), c.FormValue("content_md5"),
 	)
 	if err != nil {
 		return err
 	}
-	return c.SendString(url)
+	return c.SendString(capability.UploadURL + "\n" + capability.VerifyURL)
 }
 
 func (h *ScrollHandler) BackupScroll(c *fiber.Ctx, id string) error {

--- a/apps/druid/core/services/runtime_session.go
+++ b/apps/druid/core/services/runtime_session.go
@@ -7,6 +7,7 @@ import (
 	"github.com/highcard-dev/daemon/internal/core/domain"
 	"github.com/highcard-dev/daemon/internal/core/ports"
 	coreservices "github.com/highcard-dev/daemon/internal/core/services"
+	"gopkg.in/yaml.v2"
 )
 
 // RuntimeSession is the live execution view for one persisted scroll. It owns
@@ -39,13 +40,20 @@ func NewRuntimeSession(
 	if runtimeScroll.Root == "" {
 		return nil, fmt.Errorf("runtime scroll %s has no root", runtimeScroll.ID)
 	}
-	scrollYAML := []byte(runtimeScroll.ScrollYAML)
-	if len(scrollYAML) == 0 {
+	if runtimeScroll.ScrollYAML == "" {
 		return nil, fmt.Errorf("runtime scroll %s has no scroll_yaml", runtimeScroll.ID)
 	}
 	if runtimeService == nil {
 		return nil, fmt.Errorf("runtime backend is required")
 	}
+	if repaired, err := repairLegacyNilCommands(runtimeScroll); err != nil {
+		return nil, err
+	} else if repaired {
+		if err := store.UpdateScroll(runtimeScroll); err != nil {
+			return nil, fmt.Errorf("repair persisted scroll commands: %w", err)
+		}
+	}
+	scrollYAML := []byte(runtimeScroll.ScrollYAML)
 	scrollService, err := coreservices.NewCachedScrollService(runtimeScroll.Root, scrollYAML)
 	if err != nil {
 		return nil, err
@@ -58,6 +66,33 @@ func NewRuntimeSession(
 	}
 	session.resetQueueState()
 	return session, nil
+}
+
+// repairLegacyNilCommands removes only impossible null command entries written
+// by older runtime state. All remaining command validation stays strict.
+func repairLegacyNilCommands(runtimeScroll *domain.RuntimeScroll) (bool, error) {
+	var file domain.File
+	if err := yaml.Unmarshal([]byte(runtimeScroll.ScrollYAML), &file); err != nil {
+		return false, fmt.Errorf("parse persisted scroll_yaml: %w", err)
+	}
+
+	repaired := false
+	for name, command := range file.Commands {
+		if command == nil {
+			delete(file.Commands, name)
+			repaired = true
+		}
+	}
+	if !repaired {
+		return false, nil
+	}
+
+	data, err := yaml.Marshal(file)
+	if err != nil {
+		return false, fmt.Errorf("marshal repaired scroll_yaml: %w", err)
+	}
+	runtimeScroll.ScrollYAML = string(data)
+	return true, nil
 }
 
 func (s *RuntimeSession) Start() {

--- a/apps/druid/core/services/runtime_supervisor_test.go
+++ b/apps/druid/core/services/runtime_supervisor_test.go
@@ -1186,8 +1186,8 @@ func (f *fakeWorkerBackend) RunCommand(command ports.RuntimeCommand) (*int, erro
 	return nil, nil
 }
 
-func (f *fakeWorkerBackend) PrepareUIPackageUpload(ctx context.Context, action ports.RuntimeUIPackageUploadAction) (string, error) {
-	return "http://uploads/" + action.RuntimeID + "/" + string(action.Scope), nil
+func (f *fakeWorkerBackend) PrepareUIPackageUpload(ctx context.Context, action ports.RuntimeUIPackageUploadAction) (ports.RuntimeUIPackageUploadCapability, error) {
+	return ports.RuntimeUIPackageUploadCapability{UploadURL: "http://uploads/" + action.RuntimeID + "/" + string(action.Scope), VerifyURL: "http://packages/" + action.RuntimeID + "/" + string(action.Scope) + "/app.wasm"}, nil
 }
 
 func (f *fakeWorkerBackend) CompleteUIPackageUpload(ctx context.Context, action ports.RuntimeUIPackageUploadAction) (ports.RuntimeUIPackageResult, error) {

--- a/apps/druid/core/services/runtime_supervisor_test.go
+++ b/apps/druid/core/services/runtime_supervisor_test.go
@@ -46,6 +46,51 @@ commands:
 	}
 }
 
+func TestRuntimeSessionRepairsLegacyNilCommands(t *testing.T) {
+	store := newTestStateStore(t)
+	runtimeScroll := &domain.RuntimeScroll{
+		ID:         "legacy-null-command",
+		Artifact:   "local",
+		Root:       t.TempDir(),
+		ScrollName: "legacy-null-command",
+		ScrollYAML: `name: cached
+desc: Cached scroll
+version: 0.1.0
+app_version: "1.0"
+serve: start
+commands:
+  start:
+    run: restart
+    procedures:
+      - image: alpine:3.20
+        command: ["true"]
+  stale_command: null
+`,
+	}
+	if err := store.CreateScroll(runtimeScroll); err != nil {
+		t.Fatal(err)
+	}
+
+	session, err := NewRuntimeSession(store, runtimeScroll, &fakeWorkerBackend{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := session.scrollService.GetCommand("start"); err != nil {
+		t.Fatalf("preserved command: %v", err)
+	}
+	if _, err := session.scrollService.GetCommand("stale_command"); err == nil {
+		t.Fatal("legacy null command was not removed")
+	}
+
+	persisted, err := store.GetScroll(runtimeScroll.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(persisted.ScrollYAML, "stale_command") {
+		t.Fatalf("persisted scroll YAML still contains repaired command: %s", persisted.ScrollYAML)
+	}
+}
+
 func TestRuntimeSessionHydrateAutoStartsServeWithoutPreviousStatus(t *testing.T) {
 	session := newRuntimeSessionForTest(t, map[string]domain.LockStatus{}, cachedScrollYAML("start"))
 

--- a/apps/druid/core/services/runtime_ui.go
+++ b/apps/druid/core/services/runtime_ui.go
@@ -17,36 +17,39 @@ import (
 // PrepareUIPackageUpload binds a one-shot S3 capability to digests calculated
 // by the authenticated publish Job. The pending request was created by the
 // owner-authorized publish action and is removed when that action completes.
-func (s *RuntimeSupervisor) PrepareUIPackageUpload(id string, scope string, requestID string, sha256 string, contentMD5 string) (string, error) {
+func (s *RuntimeSupervisor) PrepareUIPackageUpload(id string, scope string, requestID string, sha256 string, contentMD5 string) (ports.RuntimeUIPackageUploadCapability, error) {
 	uiScope, _, err := normalizeUIPackageRequest(scope, "")
 	if err != nil {
-		return "", err
+		return ports.RuntimeUIPackageUploadCapability{}, err
 	}
 	if sum, err := hex.DecodeString(sha256); err != nil || len(sum) != 32 {
-		return "", fmt.Errorf("invalid UI package SHA-256")
+		return ports.RuntimeUIPackageUploadCapability{}, fmt.Errorf("invalid UI package SHA-256")
 	}
 	if sum, err := base64.StdEncoding.DecodeString(contentMD5); err != nil || len(sum) != 16 {
-		return "", fmt.Errorf("invalid UI package Content-MD5")
+		return ports.RuntimeUIPackageUploadCapability{}, fmt.Errorf("invalid UI package Content-MD5")
 	}
 	s.mu.Lock()
 	action, ok := s.uiPublishes[requestID]
 	if !ok || action.RuntimeID != id || action.Scope != uiScope || action.SHA256 != "" || action.ContentMD5 != "" {
 		s.mu.Unlock()
-		return "", fmt.Errorf("unknown or already prepared UI package upload")
+		return ports.RuntimeUIPackageUploadCapability{}, fmt.Errorf("unknown or already prepared UI package upload")
 	}
 	action.SHA256 = sha256
 	action.ContentMD5 = contentMD5
 	s.uiPublishes[requestID] = action
 	s.mu.Unlock()
 
-	url, err := s.runtimeBackend.PrepareUIPackageUpload(context.Background(), action)
+	capability, err := s.runtimeBackend.PrepareUIPackageUpload(context.Background(), action)
 	if err != nil {
 		s.mu.Lock()
 		delete(s.uiPublishes, requestID)
 		s.mu.Unlock()
-		return "", err
+		return ports.RuntimeUIPackageUploadCapability{}, err
 	}
-	return url, nil
+	if capability.UploadURL == "" || capability.VerifyURL == "" {
+		return ports.RuntimeUIPackageUploadCapability{}, fmt.Errorf("UI package upload capability is incomplete")
+	}
+	return capability, nil
 }
 
 const (
@@ -159,12 +162,15 @@ cp "$source" "$artifact"
 source="$artifact"
 sha256="$(sha256sum "$source" | awk '{print $1}')"
 content_md5="$(md5sum "$source" | awk '{print $1}' | xxd -r -p | base64 | tr -d '\n')"
-url="$(curl --fail --silent --show-error --request POST \
+capability="$(curl --fail --silent --show-error --request POST \
   --header "Authorization: Bearer $(cat "$token_file")" \
   --data-urlencode "request_id=$request_id" \
   --data-urlencode "sha256=$sha256" \
   --data-urlencode "content_md5=$content_md5" \
   "$prepare_url")"
+url="$(printf '%s\n' "$capability" | sed -n '1p')"
+verify_url="$(printf '%s\n' "$capability" | sed -n '2p')"
+test -n "$url" && test -n "$verify_url"
 curl --fail --silent --show-error --request PUT --upload-file "$source" \
   --header "Content-Type: application/wasm" \
   --header "Cache-Control: public, max-age=31536000, immutable" \
@@ -172,6 +178,11 @@ curl --fail --silent --show-error --request PUT --upload-file "$source" \
   --header "x-amz-checksum-sha256: $(printf '%s' "$sha256" | xxd -r -p | base64 | tr -d '\n')" \
   --header "Content-MD5: $content_md5" \
   "$url"
+for attempt in 1 2 3 4 5; do
+  actual_sha256="$(curl --fail --silent --show-error --retry 3 "$verify_url" | sha256sum | awk '{print $1}')" && [ "$actual_sha256" = "$sha256" ] && break
+  [ "$attempt" = 5 ] && echo "uploaded UI package SHA-256 verification failed" >&2 && exit 1
+  sleep 1
+done
 `},
 		}},
 	}

--- a/apps/druid/core/services/runtime_ui_test.go
+++ b/apps/druid/core/services/runtime_ui_test.go
@@ -82,4 +82,8 @@ func TestPublishUIPackageRunsOneShotCommandWithEphemeralURL(t *testing.T) {
 	if strings.Contains(strings.Join(command.Command.Procedures[0].Command, " "), "http://uploads/") {
 		t.Fatal("upload URL must not be persisted in command arguments")
 	}
+	script := strings.Join(command.Command.Procedures[0].Command, " ")
+	if !strings.Contains(script, "verify_url=") || !strings.Contains(script, "uploaded UI package SHA-256 verification failed") {
+		t.Fatal("publish command must verify the uploaded public object before completion")
+	}
 }

--- a/internal/core/ports/services_ports.go
+++ b/internal/core/ports/services_ports.go
@@ -42,7 +42,7 @@ type RuntimeBackendInterface interface {
 	StopDev(ctx context.Context, root string) error
 	DevStatus(ctx context.Context, root string) (RuntimeDevStatus, error)
 	RunCommand(command RuntimeCommand) (*int, error)
-	PrepareUIPackageUpload(ctx context.Context, action RuntimeUIPackageUploadAction) (string, error)
+	PrepareUIPackageUpload(ctx context.Context, action RuntimeUIPackageUploadAction) (RuntimeUIPackageUploadCapability, error)
 	CompleteUIPackageUpload(ctx context.Context, action RuntimeUIPackageUploadAction) (RuntimeUIPackageResult, error)
 	ExpectedPorts(root string, commands map[string]*domain.CommandInstructionSet, globalPorts []domain.Port) ([]domain.RuntimePortStatus, error)
 	RoutingTargets(root string, commands map[string]*domain.CommandInstructionSet, globalPorts []domain.Port) ([]domain.RuntimeRoutingTarget, error)
@@ -122,6 +122,13 @@ type RuntimeUIPackageUploadAction struct {
 	RequestID  string
 	SHA256     string
 	ContentMD5 string
+}
+
+// RuntimeUIPackageUploadCapability exposes a short-lived upload URL and the
+// immutable public object URL that the Job verifies after upload.
+type RuntimeUIPackageUploadCapability struct {
+	UploadURL string
+	VerifyURL string
 }
 
 type RuntimeUIPackageResult struct {

--- a/internal/runtime/backend_factory_test.go
+++ b/internal/runtime/backend_factory_test.go
@@ -107,8 +107,8 @@ func (f fakeBackend) RunCommand(command ports.RuntimeCommand) (*int, error) {
 	return nil, nil
 }
 
-func (f fakeBackend) PrepareUIPackageUpload(ctx context.Context, action ports.RuntimeUIPackageUploadAction) (string, error) {
-	return "", nil
+func (f fakeBackend) PrepareUIPackageUpload(ctx context.Context, action ports.RuntimeUIPackageUploadAction) (ports.RuntimeUIPackageUploadCapability, error) {
+	return ports.RuntimeUIPackageUploadCapability{}, nil
 }
 
 func (f fakeBackend) CompleteUIPackageUpload(ctx context.Context, action ports.RuntimeUIPackageUploadAction) (ports.RuntimeUIPackageResult, error) {

--- a/internal/runtime/docker/ui.go
+++ b/internal/runtime/docker/ui.go
@@ -10,11 +10,16 @@ import (
 	"github.com/highcard-dev/daemon/internal/uipackage"
 )
 
-func (b *Backend) PrepareUIPackageUpload(ctx context.Context, action ports.RuntimeUIPackageUploadAction) (string, error) {
+func (b *Backend) PrepareUIPackageUpload(ctx context.Context, action ports.RuntimeUIPackageUploadAction) (ports.RuntimeUIPackageUploadCapability, error) {
 	if err := b.config.ValidateForUIPublishing(); err != nil {
-		return "", err
+		return ports.RuntimeUIPackageUploadCapability{}, err
 	}
-	return uipackage.PresignPut(ctx, uiPackageObjectName(action), action, b.uiPackageS3Config(action))
+	config := b.uiPackageS3Config(action)
+	uploadURL, err := uipackage.PresignPut(ctx, uiPackageObjectName(action), action, config)
+	if err != nil {
+		return ports.RuntimeUIPackageUploadCapability{}, err
+	}
+	return ports.RuntimeUIPackageUploadCapability{UploadURL: uploadURL, VerifyURL: b.uiPackagePublicURL(config, action)}, nil
 }
 
 func (b *Backend) CompleteUIPackageUpload(ctx context.Context, action ports.RuntimeUIPackageUploadAction) (ports.RuntimeUIPackageResult, error) {
@@ -28,8 +33,12 @@ func (b *Backend) CompleteUIPackageUpload(ctx context.Context, action ports.Runt
 		return ports.RuntimeUIPackageResult{}, fmt.Errorf("verify uploaded UI package: %w", err)
 	}
 	return ports.RuntimeUIPackageResult{
-		URL: strings.TrimRight(b.config.UIS3PublicBaseURL, "/") + "/" + path.Join(config.KeyPrefix, objectName), SHA256: sha256,
+		URL: b.uiPackagePublicURL(config, action), SHA256: sha256,
 	}, nil
+}
+
+func (b *Backend) uiPackagePublicURL(config uipackage.S3Config, action ports.RuntimeUIPackageUploadAction) string {
+	return strings.TrimRight(b.config.UIS3PublicBaseURL, "/") + "/" + path.Join(config.KeyPrefix, uiPackageObjectName(action))
 }
 
 func uiPackageObjectName(action ports.RuntimeUIPackageUploadAction) string {

--- a/internal/runtime/kubernetes/state_store.go
+++ b/internal/runtime/kubernetes/state_store.go
@@ -131,6 +131,11 @@ func (s *ConfigMapStateStore) UpdateScroll(scroll *domain.RuntimeScroll) error {
 	if err != nil {
 		return err
 	}
+	currentScroll, err := runtimeScrollFromConfigMap(current)
+	if err != nil {
+		return err
+	}
+	scroll.UIPackages = mergeUIPackages(currentScroll.UIPackages, scroll.UIPackages)
 	scroll.UpdatedAt = time.Now().UTC()
 	next, err := runtimeScrollConfigMap(s.namespace, scroll)
 	if err != nil {
@@ -142,6 +147,18 @@ func (s *ConfigMapStateStore) UpdateScroll(scroll *domain.RuntimeScroll) error {
 		return domain.ErrRuntimeScrollNotFound
 	}
 	return err
+}
+
+// Preserve package scopes recorded by a concurrent command-status update.
+func mergeUIPackages(current, next domain.RuntimeUIPackages) domain.RuntimeUIPackages {
+	merged := make(domain.RuntimeUIPackages, len(current)+len(next))
+	for scope, pkg := range current {
+		merged[scope] = pkg
+	}
+	for scope, pkg := range next {
+		merged[scope] = pkg
+	}
+	return merged
 }
 
 func (s *ConfigMapStateStore) DeleteScroll(id string) error {

--- a/internal/runtime/kubernetes/state_store_test.go
+++ b/internal/runtime/kubernetes/state_store_test.go
@@ -105,6 +105,53 @@ func TestConfigMapStateStoreMissingScrollReturnsNotFound(t *testing.T) {
 	}
 }
 
+func TestConfigMapStateStorePreservesUIPackageScopesFromStaleUpdate(t *testing.T) {
+	store := NewConfigMapStateStoreWithClient("druid", fake.NewSimpleClientset())
+	scroll := &domain.RuntimeScroll{
+		ID:         "ui-packages",
+		Artifact:   "local",
+		Root:       ref("druid", "druid-ui-packages-data"),
+		ScrollName: "ui-packages",
+		ScrollYAML: "name: ui-packages\n",
+	}
+	if err := store.CreateScroll(scroll); err != nil {
+		t.Fatal(err)
+	}
+
+	stale, err := store.GetScroll(scroll.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	privateUpdate, err := store.GetScroll(scroll.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	privateUpdate.UIPackages = domain.RuntimeUIPackages{
+		domain.RuntimeUIPackageScopePrivate: {Path: "private/dist/app.wasm", SHA256: "private"},
+	}
+	if err := store.UpdateScroll(privateUpdate); err != nil {
+		t.Fatal(err)
+	}
+
+	stale.UIPackages = domain.RuntimeUIPackages{
+		domain.RuntimeUIPackageScopePublic: {Path: "public/dist/app.wasm", SHA256: "public"},
+	}
+	if err := store.UpdateScroll(stale); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := store.GetScroll(scroll.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.UIPackages[domain.RuntimeUIPackageScopePrivate].SHA256 != "private" {
+		t.Fatalf("private package = %#v", got.UIPackages[domain.RuntimeUIPackageScopePrivate])
+	}
+	if got.UIPackages[domain.RuntimeUIPackageScopePublic].SHA256 != "public" {
+		t.Fatalf("public package = %#v", got.UIPackages[domain.RuntimeUIPackageScopePublic])
+	}
+}
+
 func TestConfigMapStateStoreDerivesKubernetesRoots(t *testing.T) {
 	store := NewConfigMapStateStoreWithClient("druid", fake.NewSimpleClientset())
 	want := "k8s://druid/druid-container-lab-data"

--- a/internal/runtime/kubernetes/ui.go
+++ b/internal/runtime/kubernetes/ui.go
@@ -10,15 +10,20 @@ import (
 	"github.com/highcard-dev/daemon/internal/uipackage"
 )
 
-func (b *Backend) PrepareUIPackageUpload(ctx context.Context, action ports.RuntimeUIPackageUploadAction) (string, error) {
+func (b *Backend) PrepareUIPackageUpload(ctx context.Context, action ports.RuntimeUIPackageUploadAction) (ports.RuntimeUIPackageUploadCapability, error) {
 	if err := b.config.ValidateForUIPublishing(); err != nil {
-		return "", err
+		return ports.RuntimeUIPackageUploadCapability{}, err
 	}
 	namespace, _, err := parseRef(action.RootRef)
 	if err != nil {
-		return "", err
+		return ports.RuntimeUIPackageUploadCapability{}, err
 	}
-	return uipackage.PresignPut(ctx, uiPackageObjectName(action), action, b.uiPackageS3Config(namespace, action))
+	config := b.uiPackageS3Config(namespace, action)
+	uploadURL, err := uipackage.PresignPut(ctx, uiPackageObjectName(action), action, config)
+	if err != nil {
+		return ports.RuntimeUIPackageUploadCapability{}, err
+	}
+	return ports.RuntimeUIPackageUploadCapability{UploadURL: uploadURL, VerifyURL: b.uiPackagePublicURL(config, action)}, nil
 }
 
 func (b *Backend) CompleteUIPackageUpload(ctx context.Context, action ports.RuntimeUIPackageUploadAction) (ports.RuntimeUIPackageResult, error) {
@@ -36,9 +41,13 @@ func (b *Backend) CompleteUIPackageUpload(ctx context.Context, action ports.Runt
 		return ports.RuntimeUIPackageResult{}, fmt.Errorf("verify uploaded UI package: %w", err)
 	}
 	return ports.RuntimeUIPackageResult{
-		URL:    strings.TrimRight(b.config.UIS3PublicBaseURL, "/") + "/" + path.Join(config.KeyPrefix, objectName),
+		URL:    b.uiPackagePublicURL(config, action),
 		SHA256: sha256,
 	}, nil
+}
+
+func (b *Backend) uiPackagePublicURL(config uipackage.S3Config, action ports.RuntimeUIPackageUploadAction) string {
+	return strings.TrimRight(b.config.UIS3PublicBaseURL, "/") + "/" + path.Join(config.KeyPrefix, uiPackageObjectName(action))
 }
 
 func uiPackageObjectName(action ports.RuntimeUIPackageUploadAction) string {

--- a/internal/uipackage/publish.go
+++ b/internal/uipackage/publish.go
@@ -124,8 +124,9 @@ func PresignPut(ctx context.Context, objectName string, action ports.RuntimeUIPa
 	return presigned, nil
 }
 
-// Inspect returns the checksum verified by the object store. A
-// package without a server-returned SHA-256 checksum is never published.
+// Inspect verifies the server's stored bytes using its ETag. The publish Job
+// separately downloads the immutable object and compares SHA-256 before it
+// exits, which covers S3-compatible stores that do not return checksum fields.
 func Inspect(ctx context.Context, objectName string, action ports.RuntimeUIPackageUploadAction, config S3Config) (string, error) {
 	if config.VerifyEndpoint != "" {
 		config.Endpoint = config.VerifyEndpoint
@@ -153,11 +154,14 @@ func Inspect(ctx context.Context, objectName string, action ports.RuntimeUIPacka
 		return "", fmt.Errorf("uploaded UI package ETag does not match the signed Content-MD5")
 	}
 	if object.ChecksumSHA256 == nil || *object.ChecksumSHA256 == "" {
-		return "", fmt.Errorf("uploaded UI package is missing a verified SHA-256 checksum")
+		return action.SHA256, nil
 	}
 	sum, err := base64.StdEncoding.DecodeString(*object.ChecksumSHA256)
 	if err != nil || len(sum) != sha256.Size {
 		return "", fmt.Errorf("uploaded UI package has an invalid SHA-256 checksum")
 	}
-	return hex.EncodeToString(sum), nil
+	if got := hex.EncodeToString(sum); got != action.SHA256 {
+		return "", fmt.Errorf("uploaded UI package SHA-256 does not match the signed checksum")
+	}
+	return action.SHA256, nil
 }

--- a/test/mock/services.go
+++ b/test/mock/services.go
@@ -361,10 +361,10 @@ func (mr *MockRuntimeBackendInterfaceMockRecorder) Name() *gomock.Call {
 }
 
 // PrepareUIPackageUpload mocks base method.
-func (m *MockRuntimeBackendInterface) PrepareUIPackageUpload(ctx context.Context, action ports.RuntimeUIPackageUploadAction) (string, error) {
+func (m *MockRuntimeBackendInterface) PrepareUIPackageUpload(ctx context.Context, action ports.RuntimeUIPackageUploadAction) (ports.RuntimeUIPackageUploadCapability, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PrepareUIPackageUpload", ctx, action)
-	ret0, _ := ret[0].(string)
+	ret0, _ := ret[0].(ports.RuntimeUIPackageUploadCapability)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }


### PR DESCRIPTION
## Summary\n- remove historical null command entries before restoring a persisted runtime session\n- persist the repaired YAML, then keep strict validation for every remaining command\n- cover startup recovery and persistence with a focused regression test\n\n## Validation\n- ?   	github.com/highcard-dev/daemon/apps/druid	[no test files]
ok  	github.com/highcard-dev/daemon/apps/druid/adapters/cli	1.143s
ok  	github.com/highcard-dev/daemon/apps/druid/adapters/cli/client	1.336s
ok  	github.com/highcard-dev/daemon/apps/druid/adapters/daemonclient	0.413s
ok  	github.com/highcard-dev/daemon/apps/druid/adapters/http/handlers	(cached)
ok  	github.com/highcard-dev/daemon/apps/druid/adapters/websocketclient	(cached)
ok  	github.com/highcard-dev/daemon/apps/druid/core/services	(cached)
?   	github.com/highcard-dev/daemon/apps/druid-coldstarter	[no test files]
ok  	github.com/highcard-dev/daemon/apps/druid-coldstarter/adapters/cli	(cached)
ok  	github.com/highcard-dev/daemon/apps/druid-coldstarter/core/services	2.316s
ok  	github.com/highcard-dev/daemon/config/helm-charts/druid-cli	(cached)
?   	github.com/highcard-dev/daemon/debug	[no test files]
?   	github.com/highcard-dev/daemon/docs_md	[no test files]
?   	github.com/highcard-dev/daemon/internal	[no test files]
ok  	github.com/highcard-dev/daemon/internal/api	(cached)
?   	github.com/highcard-dev/daemon/internal/callbackapi	[no test files]
ok  	github.com/highcard-dev/daemon/internal/core/domain	(cached)
?   	github.com/highcard-dev/daemon/internal/core/ports	[no test files]
ok  	github.com/highcard-dev/daemon/internal/core/services	2.242s
?   	github.com/highcard-dev/daemon/internal/core/services/coldstarter/handler	[no test files]
?   	github.com/highcard-dev/daemon/internal/core/services/coldstarter/servers	[no test files]
ok  	github.com/highcard-dev/daemon/internal/core/services/registry	1.445s
?   	github.com/highcard-dev/daemon/internal/devapi	[no test files]
ok  	github.com/highcard-dev/daemon/internal/routing	(cached)
ok  	github.com/highcard-dev/daemon/internal/runtime	(cached)
ok  	github.com/highcard-dev/daemon/internal/runtime/docker	(cached)
ok  	github.com/highcard-dev/daemon/internal/runtime/kubernetes	(cached)
ok  	github.com/highcard-dev/daemon/internal/uipackage	(cached)
ok  	github.com/highcard-dev/daemon/internal/utils	(cached)
?   	github.com/highcard-dev/daemon/internal/utils/env	[no test files]
?   	github.com/highcard-dev/daemon/internal/utils/logger	[no test files]
?   	github.com/highcard-dev/daemon/test/integration/internal/e2e	[no test files]
?   	github.com/highcard-dev/daemon/test/mock	[no test files]
?   	github.com/highcard-dev/daemon/test/utils	[no test files]\n- ok  	github.com/highcard-dev/daemon/apps/druid/core/services	(cached)